### PR TITLE
Remove instrument, participant and status from vocabulary

### DIFF
--- a/activitystreams2-context.jsonld
+++ b/activitystreams2-context.jsonld
@@ -218,14 +218,6 @@
       "@id": "as:inReplyTo",
       "@type": "@id"
     },
-    "instrument": {
-      "@id": "as:instrument",
-      "@type": "@id"
-    },
-    "instrumentOf": {
-      "@id": "as:instrumentOf",
-      "@type": "@id"
-    },
     "items": {
       "@id": "as:items",
       "@type": "@id"
@@ -281,14 +273,6 @@
     },
     "parameter": {
       "@id": "as:parameter",
-      "@type": "@id"
-    },
-    "participant": {
-      "@id": "as:participant",
-      "@type": "@id"
-    },
-    "participantOf": {
-      "@id": "as:participantOf",
       "@type": "@id"
     },
     "prev": {
@@ -459,7 +443,6 @@
       "@id": "as:startTime",
       "@type": "xsd:dateTime"
     },
-    "status": "as:status",
     "summary": "as:summary",
     "summaryMap": {
       "@id": "as:summary",

--- a/activitystreams2-vocabulary.html
+++ b/activitystreams2-vocabulary.html
@@ -297,7 +297,6 @@
               <code><a>icon</a></code> |
               <code><a title="image-term">image</a></code> |
               <code><a>inReplyTo</a></code> |
-              <code><a>instrumentOf</a></code> |
               <code><a>memberOf</a></code> |
               <code><a>location</a></code> |
               <code><a>locationOf</a></code> |
@@ -433,12 +432,10 @@ _:c14n0 a as:Link ;
               <code><a>generatorOf</a></code> |
               <code><a>iconFor</a></code> |
               <code><a>imageOf</a></code> |
-              <code><a>instrumentOf</a></code> |
               <code><a>locationOf</a></code> |
               <code><a>memberOf</a></code> |
               <code><a>objectOf</a></code> |
               <code><a>originOf</a></code> |
-              <code><a>participantOf</a></code> |
               <code><a>previewOf</a></code> |
               <code><a>providerOf</a></code> |
               <code><a>resultOf</a></code> |
@@ -560,11 +557,8 @@ _:c14n0 a as:Activity ;
               <code><a title="object-term">object</a></code> | 
               <code><a>target</a></code> | 
               <code><a>result</a></code> | 
-              <code><a>instrument</a></code> |
               <code><a>origin</a></code> | 
-              <code><a>participant</a></code> | 
-              <code><a>priority</a></code> | 
-              <code><a>status</a></code> | 
+              <code><a>priority</a></code> |
               <code><a>to</a></code> |
               <code><a>bto</a></code> | 
               <code><a>cc</a></code> | 
@@ -740,8 +734,8 @@ _:c14n0 a as:Actor ;
         <tr>
           <td >Notes:</td>
           <td>
-            An Actor is any entity that is capable of being either the primary 
-            actor for, or participant in, an Activity. <code>Actor</code>
+            An Actor is any entity that is capable of being the primary 
+            actor for an Activity. <code>Actor</code>
             is a subclass of <code><a>Object</a></code> that serves as an 
             base class for all types of actors.
           </td>
@@ -754,8 +748,7 @@ _:c14n0 a as:Actor ;
           <td>Properties:</td>
           <td>
             <p>
-              <code><a>actorOf</a></code> | 
-              <code><a>participantOf</a></code>
+              <code><a>actorOf</a></code>
             </p>
             
             <p>
@@ -8774,8 +8767,6 @@ _c:14n0 a as:Mention ;
       <code><a>image</a></code> |
       <code><a>imageOf</a></code> |
       <code><a>inReplyTo</a></code> |
-      <code><a>instrument</a></code> |
-      <code><a>instrumentOf</a></code> |
       <code><a>last</a></code> |
       <code><a>location</a></code> |
       <code><a>locationOf</a></code> |
@@ -8788,8 +8779,6 @@ _c:14n0 a as:Mention ;
       <code><a>next</a></code> |
       <code><a>object</a></code> |
       <code><a>objectOf</a></code> |
-      <code><a>participant</a></code> |
-      <code><a>participantOf</a></code> |
       <code><a>prev</a></code> |
       <code><a>preview</a></code> |
       <code><a>previewOf</a></code> |
@@ -8829,7 +8818,6 @@ _c:14n0 a as:Mention ;
       <code><a>rating</a></code> |
       <code><a>rel</a></code> |
       <code><a>startIndex</a></code> |
-      <code><a>status</a></code> |
       <code><a>summary</a></code> |
       <code><a>title</a></code> |
       <code><a>totalItems</a></code> |
@@ -11999,252 +11987,6 @@ _c:14n0 a as:Note ;
 
       <tbody>
         <tr>
-          <td rowspan="5" ><dfn>instrument</dfn></td>
-          <td  style="width: 10%">URI:</td>
-          <td ><code>http://www.w3.org/ns/activitystreams#instrument</code></td>
-          <td rowspan="5">
-<div class="nanotabs">
-  <ul>
-    <li><a href="#ex85-jsonld" class="selected">JSON-LD</a></li>
-    <li><a href="#ex85-microdata" class="selected">Microdata</a></li>
-    <li><a href="#ex85-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex85-microformats" class="selected">Microformats</a></li>
-    <li><a href="#ex85-turtle" class="selected">Turtle</a></li>
-  </ul>
-  <div id="ex85-jsonld" style="display: block;">
-<pre class="example highlight json">{
-  "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Create",
-  "actor": "acct:sally@example.org",
-  "object": {
-    "@type": "Object",
-    "displayName": "A Paper Airplane"
-  },
-  "instrument": {
-    "@type": "Object",
-    "displayName": "Paper"
-  }
-}</pre> 
-  </div>
-  <div id="ex85-microdata" style="display: none;">
-<pre class="example highlight html"
->&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Create">
-  &lt;link itemprop="actor" 
-    href="acct:sally@example.org">Sally&lt;/link>
-  created
-  &lt;span itemprop="object"
-    itemtype="http://www.w3.org/ns/activitystreams#Object">
-    &lt;span itemprop="displayName">
-      A Paper Airplane
-    &lt;/span>
-  &lt;/span>
-  using
-  &lt;span itemprop="instrument"
-    itemtype="http://www.w3.org/ns/activitystreams#Object">
-    &lt;span itemprop="displayName">
-      Paper
-    &lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex85-rdfa" style="display: none;">
-<pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Create">
-  &lt;link property="actor" 
-    href="acct:sally@example.org">Sally&lt;/link>
-  created
-  &lt;span property="object" typeof="Object">
-    &lt;span property="displayName">
-      A Paper Airplane
-    &lt;/span>
-  &lt;/span>
-  using
-  &lt;span property="instrument" typeof="Object">
-    &lt;span property="displayName">
-      Paper
-    &lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex85-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-create">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">Sally&lt;/link>
-  created
-  &lt;span class="p-item h-entry">
-    &lt;span class="p-name">A Paper Airplane&lt;/span>
-  &lt;/span>
-  using
-  &lt;span class="p-as-instrument h-entry">
-    &lt;span class="p-name">Paper&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex85-turtle" style="display: none;">
-<pre class="example highlight turtle"
->@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
-
-_c:14n0 a as:Create ;
-  as:actor &lt;acct:sally@example.org&gt; ;
-  as:object [
-    a as:Object ;
-      as:displayName "A Paper Airplane" .
-  ] ;
-  as:instrument [
-    a as:Object ;
-      as:displayName "Paper" .
-  ] .
-</pre>
-  </div>
-</div>
-          </td>
-        </tr>
-        <tr>
-          <td>Notes:</td>
-          <td>
-            An optional <code><a>Object</a></code> | <code><a>Link</a></code> that describes one or more objects used to perform the activity. For instance, in the activity, "Sally played music with a piano", the instrument of the activity is the piano.
-          </td>
-        </tr>
-        <tr>
-          <td >Domain:</td>
-          <td ><code><a>Activity</a></code></td>
-        </tr>
-        <tr>
-          <td >Range:</td>
-          <td ><code><a>Object</a></code> | <code><a>Link</a></code></td>
-        </tr>
-        <tr>
-          <td>Inverse Of:</td>
-          <td><code><a>instrumentOf</a></code></td>
-        </tr>
-      </tbody>
-
-      <tbody>
-        <tr>
-          <td rowspan="5" ><dfn>instrumentOf</dfn></td>
-          <td  style="width: 10%">URI:</td>
-          <td ><code>http://www.w3.org/ns/activitystreams#instrumentOf</code></td>
-          <td rowspan="5">
-<div class="nanotabs">
-  <ul>
-    <li><a href="#ex86-jsonld" class="selected">JSON-LD</a></li>
-    <li><a href="#ex86-microdata" class="selected">Microdata</a></li>
-    <li><a href="#ex86-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex86-microformats" class="selected">Microformats</a></li>
-    <li><a href="#ex86-turtle" class="selected">Turtle</a></li>
-  </ul>
-  <div id="ex86-jsonld" style="display: block;">
-<pre class="example highlight json">{
-  "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Object",
-  "displayName": "Paper",
-  "instrumentOf": {
-    "@type": "Create",
-    "actor": "acct:sally@example.org",
-    "object": {
-      "@type": "Object",
-      "displayName": "A Paper Airplane"
-    }
-  }
-}</pre> 
-  </div>
-  <div id="ex86-microdata" style="display: none;">
-<pre class="example highlight html"
->&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Object">
-  &lt;span itemprop="displayName">Paper&lt;/span>
-  was used
-  &lt;span itemprop="instrumentOf" itemscope
-    itemtype="http://www.w3.org/ns/activitystreams#Create">
-    by &lt;link itemprop="actor" 
-      href="acct:sally@example.org">Sally&lt;/link>
-    to create
-    &lt;span itemprop="object"
-      itemtype="http://www.w3.org/ns/activitystreams#Object">
-      &lt;span itemprop="displayName">
-        A Paper Airplane
-      &lt;/span>
-    &lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex86-rdfa" style="display: none;">
-<pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Object">
-  &lt;span property="displayName">Paper&lt;/span>
-  was used
-  &lt;span property="instrumentOf" typeof="Create">
-    by &lt;link property="actor" 
-      href="acct:sally@example.org">Sally&lt;/link>
-    to create
-    &lt;span property="object" typeof="Object">
-      &lt;span property="displayName">
-        A Paper Airplane
-      &lt;/span>
-    &lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex86-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="p-name">Paper&lt;/span>
-  was used
-  &lt;span class="p-as-instrument-of h-as-create" >
-    by &lt;link class="u-author" 
-      href="acct:sally@example.org">Sally&lt;/link>
-    to create
-    &lt;span class="p-item h-entry">
-      &lt;span class="p-name">A Paper Airplane&lt;/span>
-    &lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex86-turtle" style="display: none;">
-<pre class="example highlight turtle"
->@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
-
-_c:14n0 a as:Object ;
-  as:displayName "Paper" ;
-  as:instrumentOf [
-    a as:Create ;
-    as:actor &lt;acct:sally@example.org&gt; ;
-    as:object [
-      a as:Object ;
-        as:displayName "A Paper Airplane" .
-    ] .
-  ] .
-</pre>
-  </div>
-</div>
-          </td>
-        </tr>
-        <tr>
-          <td>Notes:</td>
-          <td>
-            Indicates an activity that used this object.
-          </td>
-        </tr>
-        <tr>
-          <td >Domain:</td>
-          <td ><code><a>Object</a></code> | <code><a>Link</a></code></td>
-        </tr>
-        <tr>
-          <td >Range:</td>
-          <td ><code><a>Activity</a></code></td>
-        </tr>
-        <tr>
-          <td>Inverse Of:</td>
-          <td><code><a>instrument</a></code></td>
-        </tr>
-      </tbody>
-
-      <tbody>
-        <tr>
           <td rowspan="5" ><dfn>last</dfn></td>
           <td  style="width: 10%">URI:</td>
           <td ><code>http://www.w3.org/ns/activitystreams#last</code></td>
@@ -14363,238 +14105,6 @@ _c:14n0 a as:Note ;
         <tr>
           <td>Inverse Of:</td>
           <td><code><a>object</a></code></td>
-        </tr>
-      </tbody>
-
-      <tbody>
-        <tr>
-          <td rowspan="5" ><dfn>participant</dfn></td>
-          <td  style="width: 10%">URI:</td>
-          <td ><code>http://www.w3.org/ns/activitystreams#participant</code></td>
-          <td rowspan="5">
-<div class="nanotabs">
-  <ul>
-    <li><a href="#ex102-jsonld" class="selected">JSON-LD</a></li>
-    <li><a href="#ex102-microdata" class="selected">Microdata</a></li>
-    <li><a href="#ex102-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex102-microformats" class="selected">Microformats</a></li>
-    <li><a href="#ex102-turtle" class="selected">Turtle</a></li>
-  </ul>
-  <div id="ex102-jsonld" style="display: block;">
-<pre class="example highlight json">{
-  "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Watch", 
-  "actor": "acct:sally@example.org",
-  "object": "http://example.org/movie.mkv",
-  "participant": [
-    "acct:joe@example.org",
-    "acct:john@example.org"
-  ]
-}</pre>
-</div>
-<div id="ex102-microdata" style="display:none;">
-<pre class="example highlight html"
->&lt;div itemscope
-  itemtype="
-    http://www.w3.org/ns/activitystreams#Watch">
-  &lt;link itemprop="actor" 
-    href="acct:sally@example.org">Sally&lt;/link>
-  watched
-  &lt;link itemprop="object"
-    href="http://example.org/movie.mkv">
-    "http://example.org/movie.mkv"
-  &lt;/link>
-  with
-  &lt;link itemprop="participant" 
-    href="acct:joe@example.org">Joe&lt;/link> 
-  and
-  &lt;link itemprop="participant" 
-    href="acct:john@example.org">John&lt;/link>
-&lt;/div></pre>
-  </div>
-  <div id="ex102-rdfa" style="display:none;">
-<pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Watch">
-  &lt;link property="actor" 
-    href="acct:sally@example.org">Sally&lt;/link>
-  watched
-  &lt;link property="object"
-    href="http://example.org/movie.mkv">
-    "http://example.org/movie.mkv"
-  &lt;/link>
-  with
-  &lt;link property="participant" 
-    href="acct:joe@example.org">Joe&lt;/link> 
-  and
-  &lt;link property="participant" 
-    href="acct:john@example.org">John&lt;/link>
-&lt;/div></pre>
-  </div>
-  <div id="ex102-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-watch">
-  &lt;link class="u-author" 
-    href="acct:sally@example.org">Sally&lt;/link>
-  watched
-  &lt;link class="u-item"
-    href="http://example.org/movie.mkv">
-    "http://example.org/movie.mkv"
-  &lt;/link>
-  with
-  &lt;link class="u-participant" 
-    href="acct:joe@example.org">Joe&lt;/link> 
-  and
-  &lt;link class="u-participant" 
-    href="acct:john@example.org">John&lt;/link>
-&lt;/div></pre>
-  </div>
-<div id="ex102-turtle" style="display: none;">
-<pre class="example highlight turtle">
-@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
-
-_c:14n0 a as:Watch ;
-  as:actor &lt;acct:sally@example.org&gt; ;
-  as:object &lt;http://example.org/movie.mkv&gt; ;
-  as:participant (
-    &lt;acct:joe@example.org&gt; 
-    &lt;acct:john@example.org&gt;
-  ).</pre>
-  </div>
-</div>
-          </td>
-        </tr>
-        <tr>
-          <td>Notes:</td>
-          <td>
-            An optional <code><a>Object</a></code> | <code><a>Link</a></code> that describes one or more additional actors that have (or will have) participated in the activity. For instance, in the activity, "Sally went to the movies with Joe", Sally is the primary actor, while Joe is a participant.
-          </td>
-        </tr>
-        <tr>
-          <td >Domain:</td>
-          <td ><code><a>Activity</a></code></td>
-        </tr>
-        <tr>
-          <td >Range:</td>
-          <td ><code><a>Actor</a></code> | <code><a>Link</a></code></td>
-        </tr>
-        <tr>
-          <td>Inverse Of:</td>
-          <td><code><a>participantOf</a></code></td>
-        </tr>
-      </tbody>
-
-      <tbody>
-        <tr>
-          <td rowspan="5" ><dfn>participantOf</dfn></td>
-          <td  style="width: 10%">URI:</td>
-          <td ><code>http://www.w3.org/ns/activitystreams#participantOf</code></td>
-          <td rowspan="5">
-<div class="nanotabs">
-  <ul>
-    <li><a href="#ex103-jsonld" class="selected">JSON-LD</a></li>
-    <li><a href="#ex103-microdata" class="selected">Microdata</a></li>
-    <li><a href="#ex103-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex103-microformats" class="selected">Microformats</a></li>
-    <li><a href="#ex103-turtle" class="selected">Turtle</a></li>
-  </ul>
-  <div id="ex103-jsonld" style="display: block;">
-<pre class="example highlight json">{
-  "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Person",
-  "@id": "acct:joe@example.org",
-  "participantOf": {
-    "@type": "Watch", 
-    "actor": "acct:sally@example.org",
-    "object": "http://example.org/movie.mkv"
-  }
-}</pre>
-</div>
-<div id="ex103-microdata" style="display:none;">
-<pre class="example highlight html"
->&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Person"
-  itemid="acct:joe@example.org">
-  &lt;span itemprop="participantOf" itemscope
-    itemtype="
-      http://www.w3.org/ns/activitystreams#Watch">
-    &lt;link itemprop="actor" 
-      href="acct:sally@example.org">Sally&lt;/link>
-    watched
-    &lt;link itemprop="object"
-      href="http://example.org/movie.mkv">
-      "http://example.org/movie.mkv"
-    &lt;/link>
-  &lt;/span>
-  with Joe
-&lt;/div></pre>
-  </div>
-  <div id="ex103-rdfa" style="display:none;">
-<pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Person" resource="acct:joe@example.org">
-  &lt;span property="participantOf"
-    typeof="Watch">
-    &lt;link property="actor" 
-      href="acct:sally@example.org">Sally&lt;/link>
-    watched
-    &lt;link property="object"
-      href="http://example.org/movie.mkv">
-      "http://example.org/movie.mkv"
-    &lt;/link>
-  &lt;/span>
-  with Joe
-&lt;/div></pre>
-  </div>
-  <div id="ex103-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;link class="h-card"
-  href="acct:joe@example.org">
-  &lt;span class="p-as-participant-of h-as-watch">
-    &lt;link class="u-author" 
-      href="acct:sally@example.org">Sally&lt;/link>
-    watched
-    &lt;link class="u-item"
-      href="http://example.org/movie.mkv">
-      "http://example.org/movie.mkv"
-    &lt;/link>
-  &lt;/span>
-  with Joe
-&lt;/link></pre>
-  </div>
-<div id="ex103-turtle" style="display: none;">
-<pre class="example highlight turtle">
-@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
-
-&lt;acct:joe@example.org&gt; a as:Person ;
-  as:participantOf [
-    a as:Activity, 
-      &lt;urn:example:verbs:Watch&gt; ;
-      as:actor &lt;acct:sally@example.org&gt; ;
-      as:object &lt;http://example.org/movie.mkv&gt; .
-  ] .</pre>
-  </div>
-</div>
-          </td>
-        </tr>
-        <tr>
-          <td>Notes:</td>
-          <td>
-            Identifies that this <code><a>Actor</a></code> is a participant of
-            the referenced <code><a>Activity</a></code>
-          </td>
-        </tr>
-        <tr>
-          <td >Domain:</td>
-          <td ><code><a>Actor</a></code> | <code><a>Link</a></code></td>
-        </tr>
-        <tr>
-          <td >Range:</td>
-          <td ><code><a>Activity</a></code></td>
-        </tr>
-        <tr>
-          <td>Inverse Of:</td>
-          <td><code><a>participant</a></code></td>
         </tr>
       </tbody>
 
@@ -19724,133 +19234,6 @@ _c:14n0 a as:OrderedCollection ;
 
       <tbody>
         <tr>
-          <td rowspan="5" ><dfn>status</dfn></td>
-          <td  style="width: 10%">URI:</td>
-          <td ><code>http://www.w3.org/ns/activitystreams#status</code></td>
-          <td rowspan="5">
-<div class="nanotabs">
-  <ul>
-    <li><a href="#ex151-jsonld" class="selected">JSON-LD</a></li>
-    <li><a href="#ex151-microdata" class="selected">Microdata</a></li>
-    <li><a href="#ex151-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex151-microformats" class="selected">Microformats</a></li>
-    <li><a href="#ex151-turtle" class="selected">Turtle</a></li>
-  </ul>
-  <div id="ex151-jsonld" style="display: block;">
-<pre class="example highlight json">{
-  "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
-  "actor": "acct:sally@example.org",
-  "object": "http://example.org/posts/1",
-  "target": "acct:john@example.org",
-  "status": "pending"
-}</pre> 
-  </div>
-  <div id="ex151-microdata" style="display: none;">
-<pre class="example highlight html"
->&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
-  &lt;link itemprop="actor"
-    href="acct:sally@example.org">
-    Sally
-  &lt;/link>
-  shared
-  &lt;a itemprop="object"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link itemprop="target"
-    href="acct:john@example.org">
-    John
-  &lt;/link>
-  &lt;meta itemprop="status" content="pending" />
-&lt;/div></pre>
-  </div>
-  <div id="ex151-rdfa" style="display: none;">
-<pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
-  &lt;link property="actor"
-    href="acct:sally@example.org">
-    Sally
-  &lt;/link>
-  shared
-  &lt;a property="object"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link property="target"
-    href="acct:john@example.org">
-    John
-  &lt;/link>
-  &lt;meta property="status" content="pending" />
-&lt;/div></pre>
-  </div>
-  <div id="ex151-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">
-      Sally
-  &lt;link> 
-  shared
-  &lt;a class="u-share-of"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link class="u-as-target"
-    href="acct:sally@example.org">
-      John
-  &lt;link> 
-  &lt;meta class="p-as-status" name="status" 
-    content="pending" />
-&lt;/div></pre>
-  </div>
-  <div id="ex151-turtle" style="display: none;">
-<pre class="example highlight turtle"
->@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
-
-_c:14n0 a as:Share ;
-  as:actor &lt;acct:sally@example.org&gt; ;
-  as:object &lt;http://example.org/posts/1&gt; ;
-  as:target &lt;acct:john@example.org&gt; ;
-  as:status "pending" .
-</pre>
-  </div>
-</div>
-          </td>
-        </tr>
-        <tr>
-          <td >Notes:</td>
-          <td >
-            An optional, explicit indicator of the current status of the activity.
-          </td>
-        </tr>
-        <tr>
-          <td >Domain:</td>
-          <td ><code><a>Activity</a></code></td>
-        </tr>
-        <tr>
-          <td >Range:</td>
-          <td >
-           "<code>active</code>" | 
-           "<code>canceled</code>" | 
-           "<code>completed</code>" | 
-           "<code>pending</code>" | 
-           "<code>voided</code>" | 
-           <code>xsd:anyURI</code></td>
-        </tr>
-        <tr>
-          <td>Functional:</td>
-          <td>True</td>
-        </tr>
-      </tbody>
-
-      <tbody>
-        <tr>
           <td rowspan="4" ><dfn>summary</dfn></td>
           <td  style="width: 10%">URI:</td>
           <td ><code>http://www.w3.org/ns/activitystreams#summary</code></td>
@@ -21142,24 +20525,6 @@ as:inReplyTo a owl:ObjectProperty ;
     owl:unionOf ( as:Object as:LinkNotHandler ) .
   ] .
 
-as:instrument a owl:ObjectProperty ;
-  rdfs:label "instrument"@en ; 
-  rdfs:domain as:Activity ;
-  rdfs:subPropertyOf prov:used ;
-  rdfs:range [
-    a owl:Class ;
-    owl:unionOf ( as:Object as:LinkNotHandler ) .
-  ] .
-
-as:instrumentOf a owl:ObjectProperty ; 
-  rdfs:label "instrumentOf"@en ;       
-  rdfs:range as:Activity ;
-  rdfs:domain [
-    a owl:Class ;
-    owl:unionOf ( as:Object as:LinkNotHandler ) .
-  ] ;
-  owl:inverseOf as:instrument .
-
 as:items a owl:ObjectProperty, 
            owl:FunctionalProperty ;  
   rdfs:label "items"@en ;       
@@ -21268,24 +20633,6 @@ as:parameter a owl:ObjectProperty ;
     owl:unionOf (as:HtmlForm as:UrlTemplate)  .
   ] ;
   rdfs:range as:Parameter .
-
-as:participant a owl:ObjectProperty ;   
-  rdfs:label "participant"@en ;    
-  rdfs:domain as:Activity ;
-  rdfs:subPropertyOf prov:wasAssociatedWith ;
-  rdfs:range [
-    a owl:Class ;
-    owl:unionOf ( as:Actor as:LinkNotHandler ) .
-  ] .
-
-as:participantOf a owl:ObjectProperty ;   
-  rdfs:label "participantOf"@en ;      
-  rdfs:range as:Activity ;
-  rdfs:domain [
-    a owl:Class ;
-    owl:unionOf ( as:Actor as:LinkNotHandler ) .
-  ] ;
-  owl:inverseOf as:participant .
 
 as:prev a owl:FunctionalProperty ,
           owl:ObjectProperty ;
@@ -21789,28 +21136,6 @@ as:startTime a owl:DatatypeProperty ,
   rdfs:subPropertyOf prov:startedAtTime ;
   rdfs:range xsd:dateTime ;
   rdfs:domain as:Object .
-
-as:status a owl:DatatypeProperty ,
-            owl:FunctionalProperty ;
-  rdfs:label "status"@en ;
-  rdfs:comment "Explicitly identifies the current state of an Activity."@en ;
-  rdfs:domain as:Activity ;
-  rdfs:range [
-    a rdfs:Datatype ;
-    owl:unionOf (
-      [
-        a rdfs:Datatype ;
-        owl:oneOf (
-          "pending"
-          "active"
-          "completed"
-          "canceled"
-          "voided"
-        ) .
-      ]
-      xsd:anyURI
-    ) .
-  ] .
 
 as:summary a owl:DatatypeProperty ;
   rdfs:label "summary"@en ;

--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -846,7 +846,6 @@ _:c14n0 a as:Collection ;
           <code><a href="activitystreams2-vocabulary.html#dfn-icon">icon</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-image-term">image</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-inreplyto">inReplyTo</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-instrumentof">instrumentOf</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-memberof">memberOf</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-location">location</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-locationof">locationOf</a></code> |
@@ -1458,12 +1457,10 @@ _:c14n0 a as:Object ;
           <code><a href="activitystreams2-vocabulary.html#dfn-generatorof">generatorOf</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-iconfor">iconFor</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-imageof">imageOf</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-instrumentof">instrumentOf</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-locationof">locationOf</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-memberof">memberOf</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-objectof">objectOf</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-originof">originOf</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-participantof">participantOf</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-previewof">previewOf</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-providerof">providerOf</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-resultof">resultOf</a></code> |
@@ -2127,11 +2124,8 @@ _:c14n0 a as:Share ;
           <code><a href="activitystreams2-vocabulary.html#dfn-object-term">object</a></code> | 
           <code><a href="activitystreams2-vocabulary.html#dfn-target">target</a></code> | 
           <code><a href="activitystreams2-vocabulary.html#dfn-origin">origin</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-result">result</a></code> | 
-          <code><a href="activitystreams2-vocabulary.html#dfn-instrument">instrument</a></code> | 
-          <code><a href="activitystreams2-vocabulary.html#dfn-participant">participant</a></code> | 
-          <code><a href="activitystreams2-vocabulary.html#dfn-priority">priority</a></code> | 
-          <code><a href="activitystreams2-vocabulary.html#dfn-status">status</a></code> | 
+          <code><a href="activitystreams2-vocabulary.html#dfn-result">result</a></code> |
+          <code><a href="activitystreams2-vocabulary.html#dfn-priority">priority</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-to">to</a></code> | 
           <code><a href="activitystreams2-vocabulary.html#dfn-bto">bto</a></code> | 
           <code><a href="activitystreams2-vocabulary.html#dfn-cc">cc</a></code> | 

--- a/activitystreams2.owl
+++ b/activitystreams2.owl
@@ -306,24 +306,6 @@ as:inReplyTo a owl:ObjectProperty ;
     owl:unionOf ( as:Object as:LinkNotHandler ) .
   ] .
 
-as:instrument a owl:ObjectProperty ;
-  rdfs:label "instrument"@en ; 
-  rdfs:domain as:Activity ;
-  rdfs:subPropertyOf prov:used ;
-  rdfs:range [
-    a owl:Class ;
-    owl:unionOf ( as:Object as:LinkNotHandler ) .
-  ] .
-
-as:instrumentOf a owl:ObjectProperty ; 
-  rdfs:label "instrumentOf"@en ;       
-  rdfs:range as:Activity ;
-  rdfs:domain [
-    a owl:Class ;
-    owl:unionOf ( as:Object as:LinkNotHandler ) .
-  ] ;
-  owl:inverseOf as:instrument .
-
 as:items a owl:ObjectProperty, 
            owl:FunctionalProperty ;  
   rdfs:label "items"@en ;       
@@ -432,24 +414,6 @@ as:parameter a owl:ObjectProperty ;
     owl:unionOf (as:HtmlForm as:UrlTemplate)  .
   ] ;
   rdfs:range as:Parameter .
-
-as:participant a owl:ObjectProperty ;   
-  rdfs:label "participant"@en ;    
-  rdfs:domain as:Activity ;
-  rdfs:subPropertyOf prov:wasAssociatedWith ;
-  rdfs:range [
-    a owl:Class ;
-    owl:unionOf ( as:Actor as:LinkNotHandler ) .
-  ] .
-
-as:participantOf a owl:ObjectProperty ;   
-  rdfs:label "participantOf"@en ;      
-  rdfs:range as:Activity ;
-  rdfs:domain [
-    a owl:Class ;
-    owl:unionOf ( as:Actor as:LinkNotHandler ) .
-  ] ;
-  owl:inverseOf as:participant .
 
 as:prev a owl:FunctionalProperty ,
           owl:ObjectProperty ;
@@ -953,28 +917,6 @@ as:startTime a owl:DatatypeProperty ,
   rdfs:subPropertyOf prov:startedAtTime ;
   rdfs:range xsd:dateTime ;
   rdfs:domain as:Object .
-
-as:status a owl:DatatypeProperty ,
-            owl:FunctionalProperty ;
-  rdfs:label "status"@en ;
-  rdfs:comment "Explicitly identifies the current state of an Activity."@en ;
-  rdfs:domain as:Activity ;
-  rdfs:range [
-    a rdfs:Datatype ;
-    owl:unionOf (
-      [
-        a rdfs:Datatype ;
-        owl:oneOf (
-          "pending"
-          "active"
-          "completed"
-          "canceled"
-          "voided"
-        ) .
-      ]
-      xsd:anyURI
-    ) .
-  ] .
 
 as:summary a owl:DatatypeProperty ;
   rdfs:label "summary"@en ;


### PR DESCRIPTION
The instrument, participant and status properties have very little real world justification for inclusion in the core vocabulary based on an analysis of relevant use cases. I recommend dropping these.