### PR TITLE
gsp - recommended prefix for GeoSparql

### DIFF
--- a/activitystreams2-context.jsonld
+++ b/activitystreams2-context.jsonld
@@ -9,7 +9,7 @@
     "org": "http://www.w3.org/ns/org#",
     "prov": "http://www.w3.org/ns/prov#",
     "geo": "http://www.w3.org/2003/01/geo/wgs84_pos#",
-    "geos": "http://www.opengis.net/ont/geosparql#",
+    "gsp": "http://www.opengis.net/ont/geosparql#",
     "ical": "http://www.w3.org/2002/12/cal/ical#",
     "xsd": "http://www.w3.org/2001/XMLSchema#"
   },
@@ -488,7 +488,7 @@
     }
   },
  {
-    "geos:asWKT": { "@type": "geos:wktLiteral" },
+    "gsp:asWKT": { "@type": "gsp:wktLiteral" },
     "geo:alt": {"@type": "xsd:float"},
     "geo:lat": {"@type": "xsd:float"},
     "geo:long": {"@type": "xsd:float"},

--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -2906,8 +2906,8 @@ _:c14n0 a as:Place;
   <div id="ex24-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "geos:Geometry",
-  "geos:asWKT": "Polygon((100.0, 0.0, 101.0, 0.0, 101.0, 1.0, 100.0, 1.0, 100.0, 0.0))"
+  "@type": "gsp:Geometry",
+  "gsp:asWKT": "Polygon((100.0, 0.0, 101.0, 0.0, 101.0, 1.0, 100.0, 1.0, 100.0, 0.0))"
 }</pre>
 </div>
   <div id="ex24-microdata" style="display:none;">
@@ -2935,10 +2935,10 @@ _:c14n0 a as:Place;
   <div id="ex24-turtle" style="display:none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
-@prefix geos: &lt;http://www.opengis.net/ont/geosparql#&gt; .
+@prefix gsp: &lt;http://www.opengis.net/ont/geosparql#&gt; .
 
-_:c14n0 a geos:Geometry ;
-  geos:asWKT "Polygon((100.0, 0.0, 101.0, 0.0, 101.0, 1.0, 100.0, 1.0, 100.0, 0.0))"^^geos:wktLiteral .</pre></div>
+_:c14n0 a gsp:Geometry ;
+  gsp:asWKT "Polygon((100.0, 0.0, 101.0, 0.0, 101.0, 1.0, 100.0, 1.0, 100.0, 0.0))"^^gsp:wktLiteral .</pre></div>
 </div>
 </figure>
 
@@ -3030,7 +3030,7 @@ _:c14n0 a geos:Geometry ;
             <td>W3C Basic Geo Ontology</td>
           </tr>
           <tr>
-            <td><code>geos:</code></td>
+            <td><code>gsp:</code></td>
             <td><code>http://www.opengis.net/ont/geosparql#</code></td>
             <td>Geo-Sparql</td>
           </tr>


### PR DESCRIPTION
GeoSparql uses gsp prefix, not geos

* http://prefix.cc/gsp
* http://lov.okfn.org/dataset/lov/vocabs/gsp