### PR TITLE
adding profile media type parameter

### DIFF
--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -3250,7 +3250,15 @@ _:c14n0 a geos:Geometry ;
         </tr>
         <tr>
           <td>Optional parameters: </td>
-          <td>None</td>
+          <td>profile: The profile parameter for the application/activity+json media type allows
+   one or more profile URIs to be specified.  These profile URIs have
+   the identifier semantics defined in [[!RFC6906]]. The "profile" media type parameter MUST be quoted.
+   It contains a non-empty list of space-separated URIs (the profile URIs).
+   <pre>profile-param = "profile=" profile-value
+profile-value = <"> profile-URI 0*( 1*SP profile-URI ) <">
+profile-URI   = URI</pre>
+   The "URI" in the above grammar refers to the "URI" as defined in
+   Section 3 of [[!RFC3986]].</td>
         </tr>
         <tr>
           <td>Encoding considerations: </td>
@@ -3297,7 +3305,15 @@ _:c14n0 a geos:Geometry ;
         </tr>
         <tr>
           <td>Optional parameters: </td>
-          <td>None</td>
+          <td>profile: The profile parameter for the application/stream+json media type allows
+   one or more profile URIs to be specified.  These profile URIs have
+   the identifier semantics defined in [[!RFC6906]]. The "profile" media type parameter MUST be quoted.
+   It contains a non-empty list of space-separated URIs (the profile URIs).
+   <pre>profile-param = "profile=" profile-value
+profile-value = <"> profile-URI 0*( 1*SP profile-URI ) <">
+profile-URI   = URI</pre>
+   The "URI" in the above grammar refers to the "URI" as defined in
+   Section 3 of [[!RFC3986]].</td>
         </tr>
         <tr>
           <td>Encoding considerations: </td>


### PR DESCRIPTION
the proposal is to add a profile media type parameter to both media types. it would allow profiles to be identified at the media type level. profiles according to RFC 6906 could be used to signal certain vocabularies that an activity stream may use (or that a client prefers). https://github.com/dret/ASDL is one way how such a profile could be represented (currently ASDL is focusing on AS1), but the profile parameter would not require a specific representation, or any at all. it would simply signify that an activity stream follows a profile.