### PR TITLE
removing as:Link in favour of as:Object

### DIFF
--- a/activitystreams2-context.jsonld
+++ b/activitystreams2-context.jsonld
@@ -29,6 +29,7 @@
     "Article": "as:Article",
     "Assign": "as:Assign",
     "Audio": "as:Audio",
+    "Blob": "as:Blob",
     "Block": "as:Block",
     "BrowserView": "as:BrowserView",
     "Collection": "as:Collection",
@@ -53,6 +54,7 @@
     "HttpRequest": "as:HttpRequest",
     "Ignore": "as:Ignore",
     "Image": "as:Image",
+    "ImageBlob": "as:ImageBlob",
     "Invite": "as:Invite",
     "Join": "as:Join",
     "Leave": "as:Leave",
@@ -157,6 +159,10 @@
     },
     "current": {
       "@id": "as:current",
+      "@type": "@id"
+    },
+    "encoding": {
+      "@id": "as:encoding",
       "@type": "@id"
     },
     "first": {

--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -350,8 +350,8 @@ _:b0 a as:Post ;
    "displayName": "Martin Smith",
    "url": "http://example.org/martin",
    "image": {
-     "@type": "Link",
-     "href": "http://example.org/martin/image.jpg",
+     "@id": "http://example.org/martin/image.jpg",
+     "@type": "ImageBlob",
      "mediaType": "image/jpeg"
    }
   },
@@ -457,11 +457,10 @@ _:b0 a as:Post ;
 &lt;urn:example:person:martin&gt; a as:Person ;
   as:displayName "Martin Smith" ;
   as:url &lt;http://example.org/martin&gt; ;
-  as:image [
-    a as:Link ;
-      as:href &lt;http://example.org/martin/image.jpg&gt; ;
-      as:mediaType "image/jpeg"
-  ] .
+  as:image &lt;http://example.org/martin/image.jpg&gt; .
+
+&lt;http://example.org/martin/image.jpg&gt; a as:ImageBlob ;
+  as:mediaType "image/jpeg" .
 
 &lt;http://example.org/blog/&gt; a &lt;urn:example:types:blog&gt; ;
   as:displayName "Martin's Blog" .
@@ -519,8 +518,8 @@ _:b0 a as:Post ;
         "displayName": "Martin Smith",
         "url": "http://example.org/martin",
         "image": {
-          "@type": "Link",
-          "href": "http://example.org/martin/image",
+          "@id": "http://example.org/martin/image",
+          "@type": "ImageBlob",
           "mediaType": "image/jpeg",
           "width": 250,
           "height": 250
@@ -530,19 +529,19 @@ _:b0 a as:Post ;
         "@type": "Image",
         "@id": "http://example.org/album/my_fluffy_cat",
         "preview": {
-          "@type": "Link",
-          "href": "http://example.org/album/my_fluffy_cat_thumb.jpg",
+          "@id": "http://example.org/album/my_fluffy_cat_thumb.jpg",
+          "@type": "ImageBlob",
           "mediaType": "image/jpeg"
         },
-        "url": [
+        "encoding": [
           {
-            "@type": "Link",
-            "href": "http://example.org/album/my_fluffy_cat.jpg",
+            "@id": "http://example.org/album/my_fluffy_cat.jpg",
+            "@type": "ImageBlob",
             "mediaType": "image/jpeg"
           },
           {
-            "@type": "Link",
-            "href": "http://example.org/album/my_fluffy_cat.png",
+            "@id": "http://example.org/album/my_fluffy_cat.png",
+            "@type": "ImageBlob",
             "mediaType": "image/png"
           }
         ]
@@ -555,8 +554,8 @@ _:b0 a as:Post ;
           "ga": "Grianghraif Mairtin"
         },
         "image": {
-          "@type": "Link",
-          "href": "http://example.org/album/thumbnail.jpg",
+          "@id": "http://example.org/album/thumbnail.jpg",
+          "@type": "ImageBlob",
           "mediaType": "image/jpeg"
         }
       }
@@ -733,39 +732,35 @@ _:b0 a as:Post ;
 &lt;urn:example:person:martin&gt; a as:Person ;
   as:displayName "Martin Smith" ;
   as:url &lt;http://example.org/martin&gt; ;
-  as:image [
-    a as:Link ;
-      as:href &lt;http://example.org/martin/image&gt; ;
-      as:mediaType "image/jpeg" ;
-      as:width "250"^^xsd:nonNegativeInteger ;
-      as:height "250"^^xsd:nonNegativeInteger
-  ] .
+  as:image &lt;http://example.org/martin/image&gt; .
+
+&lt;http://example.org/martin/image&gt; a as:ImageBlob ;
+  as:mediaType "image/jpeg" ;
+  as:width "250"^^xsd:nonNegativeInteger ;
+  as:height "250"^^xsd:nonNegativeInteger .
 
 &lt;http://example.org/album/my_fluffy_cat&gt; a as:Image ;
-  as:preview [
-    a as:Link ;
-      as:href &lt;http://example.org/album/my_fluffy_cat_thumb.jpg&gt; ;
-      as:mediaType "image/jpeg"
-  ] ;
-  as:url [
-    a as:Link ;
-      as:href &lt;http://example.org/album/my_fluffy_cat.jpg&gt; ;
-      as:mediaType "image/jpeg"
-  ],
-  [
-    a as:Link ;
-      as:href &lt;http://example.org/album/my_fluffy_cat.png&gt; ;
-      as:mediaType "image/png"
-  ] .
+  as:preview &lt;http://example.org/album/my_fluffy_cat_thumb.jpg&gt; ;
+  as:encoding &lt;http://example.org/album/my_fluffy_cat.jpg&gt; ,
+         &lt;http://example.org/album/my_fluffy_cat.png&gt; .
+
+
+&lt;http://example.org/album/my_fluffy_cat_thumb.jpg&gt; a as:ImageBlob ;
+  as:mediaType "image/jpeg" .
+
+&lt;http://example.org/album/my_fluffy_cat.jpg&gt; a as:ImageBlob ;
+  as:mediaType "image/jpeg" .
+
+&lt;http://example.org/album/my_fluffy_cat.png&gt; a as:ImageBlob ;
+  as:mediaType "image/png" .
 
 &lt;http://example.org/album/&gt; a as:Album ;
   as:displayName "Martin's Photo Album"@en ;
   as:displayName "Grianghraif Mairtin"@ga ;
-  as:image [
-    a as:Link ;
-      as:href &lt;http://example.org/album/thumbnail.jpg&gt; ;
-      as:mediaType "image/jpeg"
-  ] .
+  as:image &lt;http://example.org/album/thumbnail.jpg&gt; .
+
+&lt;http://example.org/album/thumbnail.jpg&gt; a as:ImageBlob ;
+  as:mediaType "image/jpeg" .
 
 _:b0 a as:Collection ;
   as:totalItems "1"^^xsd:nonNegativeInteger ;

--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -971,10 +971,7 @@ value of <code>object</code> is not:</figcaption>
     "@id": "http://example.org/~sally",
     "displayName": "Sally"
   },
-  "object": {
-    "@type": "Link",
-    "href": "http://example.org/posts/1"
-  }
+  "object": "http://example.org/posts/1"
 }</pre>
   </div>
   <div id="ex5-microdata" style="display: none;">
@@ -1032,10 +1029,8 @@ value of <code>object</code> is not:</figcaption>
 &lt;http://example.org/foo&gt; a as:Share ;
   as:displayName "A Test" ;
   as:actor &lt;http://example.org/~sally&gt; ;
-  as:object [
-    a as:Link ;
-      as:href &lt;http://example.org/posts/1&gt;
-  ] .</pre></div>
+  as:object &lt;http://example.org/posts/1&gt; .
+</pre></div>
 </div>
 </figure>
 


### PR DESCRIPTION
As proposal for [ISSUE-14: as:Link adds a lot of complexity, if we keep it we need to clarify consequences of using it instead of as:Object](https://www.w3.org/Social/track/issues/14) I started removing as:Link from examples and for encoding of images define new **ImageBlob** class and **encoding** property.

I will draw a diagram explaining problem with as:Link and add it to this description.

Not ready to merge, work in progress to discuss issue around concrete examples from the spec!