### PR TITLE
Remove rel from as:Link

### DIFF
--- a/activitystreams2-context.jsonld
+++ b/activitystreams2-context.jsonld
@@ -308,7 +308,6 @@
       "@id": "as:rating",
       "@type": "xsd:float"
     },
-    "rel": "as:rel",
     "startIndex": {
       "@id": "as:startIndex",
       "@type": "xsd:nonNegativeInteger"

--- a/activitystreams2-vocabulary.html
+++ b/activitystreams2-vocabulary.html
@@ -398,7 +398,6 @@ _:b0 a as:Link ;
           <td>
             <p>
               <code><a>href</a></code> |
-              <code><a>rel</a></code> |
               <code><a>mediaType</a></code> |
               <code><a>displayName</a></code> |
               <code><a>title</a></code> |
@@ -8116,7 +8115,6 @@ _:b0 a as:Mention ;
       <code><a>startTime</a></code> |
       <code><a>radius</a></code> |
       <code><a>rating</a></code> |
-      <code><a>rel</a></code> |
       <code><a>startIndex</a></code> |
       <code><a>summary</a></code> |
       <code><a>title</a></code> |
@@ -16125,91 +16123,6 @@ _:b0 a as:Review ;
         </tr>
       </tbody>
 
-
-      <tbody>
-        <tr>
-          <td rowspan="4" ><dfn>rel</dfn></td>
-          <td  style="width: 10%">URI:</td>
-          <td ><code>http://www.w3.org/ns/activitystreams#rel</code></td>
-          <td rowspan="4">
-<div class="nanotabs">
-  <ul>
-    <li><a href="#ex149-jsonld" class="selected">JSON-LD</a></li>
-    <li><a href="#ex149-microdata" class="selected">Microdata</a></li>
-    <li><a href="#ex149-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex149-microformats" class="selected">Microformats</a></li>
-    <li><a href="#ex149-turtle" class="selected">Turtle</a></li>
-  </ul>
-  <div id="ex149-jsonld" style="display: block;">
-<pre class="example highlight json">{
-  "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Link",
-  "href": "http://example.org/abc",
-  "hreflang": "en",
-  "mediaType": "text/html",
-  "displayName": "An example link",
-  "rel": ["canonical", "preview"]
-}</pre>
-  </div>
-  <div id="ex149-microdata" style="display: none;">
-<pre class="example highlight html"
->&lt;a itemscope
-    itemtype="http://www.w3.org/ns/activitystreams#Link"
-    href="http://example.org/abc"
-    hreflang="en"
-    type="text/html"
-    rel="canonical preview"
-    itemprop="displayName">An example link&lt;/a></pre>
-  </div>
-  <div id="ex149-rdfa" style="display: none;">
-<pre class="example highlight json"
->&lt;a vocab="http://www.w3.org/ns/activitystreams#"
-    typeof="Link"
-    href="http://example.org/abc"
-    hreflang="en"
-    type="text/html"
-    rel="canonical preview"
-    property="displayName">An example link&lt;/a></pre>
-  </div>
-  <div id="ex149-microformats" style="display: none;">
-<pre class="example highlight json"
->&lt;a class="h-entry p-name"
-    href="http://example.org/abc"
-    hreflang="en"
-    rel="canonical preview"
-    type="text/html">An example link&lt;/a></pre>
-  </div>
-  <div id="ex149-turtle" style="display: none;">
-<pre class="example highlight turtle"
->
-@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
-
-_:b0 a as:Link ;
-  as:displayName "An example link" ;
-  as:href &lt;http://example.org/abc&gt; ;
-  as:hreflang "en" ;
-  as:rel ["canonical" "preview"] ;
-  as:mediaType "text/html" .</pre>
-  </div>
-</div>
-          </td>
-        </tr>
-        <tr>
-          <td >Notes:</td>
-          <td >
-            An RFC 5988 Link Relation associated with a <code><a>Link</a></code>.
-          </td>
-        </tr>
-        <tr>
-          <td >Domain:</td>
-          <td ><code><a>Link</a></code></td>
-        </tr>
-        <tr>
-          <td >Range:</td>
-          <td >[[!RFC5988]] or <a class="bibref" href="http://www.w3.org/TR/html5/document-metadata.html#attr-link-rel">[HTML5]</a> Link Relation</td>
-        </tr>
-      </tbody>
-
       <tbody>
          <tr>
             <td rowspan="5" ><dfn>startIndex</dfn></td>
@@ -18143,12 +18056,6 @@ _:b0 a as:Connection ;
         [ xsd:minInclusive "0.0"^^xsd:float ]
         [ xsd:maxInclusive "5.0"^^xsd:float ]
       )] .
-
-  as:rel a owl:DatatypeProperty ;
-    rdfs:label "rel"@en ;
-    rdfs:comment "The RFC 5988 or HTML5 Link Relation associated with the Link"@en ;
-    rdfs:range xsd:string ;
-    rdfs:domain as:Link .
 
   as:startIndex a owl:DatatypeProperty ,
           owl:FunctionalProperty ;

--- a/activitystreams2-vocabulary.html
+++ b/activitystreams2-vocabulary.html
@@ -6213,6 +6213,7 @@ _:b0 a as:Service ;
     "@type": "Person",
     "displayName": "Sally"
   },
+  "relationship": "http://example.org/relationship/knows",
   "b": {
     "@type": "Person",
     "displayName": "John"
@@ -6227,7 +6228,10 @@ _:b0 a as:Service ;
     itemtype="http://www.w3.org/ns/activitystreams#Person">
     &lt;span itemprop="displayName">Sally&lt;/span>
   &lt;/span>
-  is connected to
+  &lt;span itemprop="relationship"
+    itemid="http://example.org/relationship/knows">
+    knows
+  &lt;/span>
   &lt;span itemprop="b" itemscope
     itemtype="http://www.w3.org/ns/activitystreams#Person">
     &lt;span itemprop="displayName">John&lt;/span>
@@ -6241,7 +6245,10 @@ _:b0 a as:Service ;
   &lt;span property="a" typeof="Person">
     &lt;span property="displayName">Sally&lt;/span>
   &lt;/span>
-  is connected to
+  &lt;span property="relationship"
+    resource="http://example.org/relationship/knows">
+    knows
+  &lt;/span>
   &lt;span property="b" typeof="Person">
     &lt;span property="displayName">John&lt;/span>
   &lt;/span>
@@ -6253,7 +6260,7 @@ _:b0 a as:Service ;
   &lt;span class="h-card">
     &lt;span class="p-name">Sally&lt;/span>
   &lt;/span>
-  is connected to
+  knows
   &lt;span class="h-card">
     &lt;span class="p-name">John&lt;/span>
   &lt;/span>
@@ -6264,6 +6271,7 @@ _:b0 a as:Service ;
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 
 _:b0 a as:Connection ;
+  as:relationship <http://example.org/relationship/knows> ;
   as:a [
     a as:Person ;
       as:displayName "Sally" .
@@ -6289,7 +6297,8 @@ _:b0 a as:Connection ;
             <td>Properties:</td>
             <td>
               <p><code><a title="a-term">a</a></code> |
-              <code title="b-term"><a title="b-term">b</a></code></p>
+              <code><a title="b-term">b</a></code> |
+              <code><a>relationship</a></code></p>
               <p>Inherits all properties from <code><a>Object</a></code>.</p>
             </td>
           </tr>
@@ -8123,7 +8132,8 @@ _:b0 a as:Mention ;
       <code><a>updated</a></code> |
       <code><a>width</a></code> |
       <code><a title="a-term">a</a></code> |
-      <code><a title="b-term">b</a></code>
+      <code><a title="b-term">b</a></code> |
+      <code><a>relationship</a></code>
     </p>
 
     <p>
@@ -17092,6 +17102,7 @@ _:b0 a as:Content ;
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 
 _:b0 a as:Connection ;
+  as:relationship <http://example.org/relationship/knows>;
   as:a [
     a as:Person ;
       as:displayName "Sally" .
@@ -17149,6 +17160,7 @@ _:b0 a as:Connection ;
     "@type": "Person",
     "displayName": "Sally"
   },
+  "relationship": "http://example.org/relationship/knows",
   "b": {
     "@type": "Person",
     "displayName": "John"
@@ -17163,7 +17175,10 @@ _:b0 a as:Connection ;
     itemtype="http://www.w3.org/ns/activitystreams#Person">
     &lt;span itemprop="displayName">Sally&lt;/span>
   &lt;/span>
-  is connected to
+  &lt;span itemprop="relationship"
+    itemid="http://example.org/relationship/knows">
+    knows
+  &lt;/span>
   &lt;span itemprop="b" itemscope
     itemtype="http://www.w3.org/ns/activitystreams#Person">
     &lt;span itemprop="displayName">John&lt;/span>
@@ -17177,7 +17192,10 @@ _:b0 a as:Connection ;
   &lt;span property="a" typeof="Person">
     &lt;span property="displayName">Sally&lt;/span>
   &lt;/span>
-  is connected to
+  &lt;span property="relationship"
+    resource="http://example.org/relationship/knows">
+    knows
+  &lt;/span>
   &lt;span property="b" typeof="Person">
     &lt;span property="displayName">John&lt;/span>
   &lt;/span>
@@ -17189,7 +17207,7 @@ _:b0 a as:Connection ;
   &lt;span class="h-card">
     &lt;span class="p-name">Sally&lt;/span>
   &lt;/span>
-  is connected to
+  knows
   &lt;span class="h-card">
     &lt;span class="p-name">John&lt;/span>
   &lt;/span>
@@ -17200,6 +17218,7 @@ _:b0 a as:Connection ;
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 
 _:b0 a as:Connection ;
+  as:relationship <http://example.org/relationship/knows>;
   as:a [
     a as:Person ;
       as:displayName "Sally" .
@@ -17232,6 +17251,113 @@ _:b0 a as:Connection ;
         <tr>
           <td>Functional:</td>
           <td>True</td>
+        </tr>
+      </tbody>
+
+      <tbody>
+        <tr>
+          <td rowspan="5" ><dfn title="relationship">relationship</dfn></td>
+          <td  style="width: 10%">URI:</td>
+          <td ><code>http://www.w3.org/ns/activitystreams#relationship</code></td>
+          <td rowspan="5">
+            <div class="nanotabs">
+              <ul>
+                <li><a href="#ex22c-jsonld" class="selected">JSON-LD</a></li>
+                <li><a href="#ex22c-microdata" class="selected">Microdata</a></li>
+                <li><a href="#ex22c-rdfa" class="selected">RDFa</a></li>
+                <li><a href="#ex22c-microformats" class="selected">Microformats</a></li>
+                <li><a href="#ex22c-turtle" class="selected">Turtle</a></li>
+              </ul>
+              <div id="ex22c-jsonld" style="display: block;">
+            <pre class="example highlight json">{
+  "@context": "http://www.w3.org/ns/activitystreams",
+  "@type": "Connection",
+  "a": {
+    "@type": "Person",
+    "displayName": "Sally"
+  },
+  "b": {
+    "@type": "Person",
+    "displayName": "John"
+  }
+}</pre>
+</div>
+<div id="ex22c-microdata" style="display:none;">
+<pre class="example highlight html"
+>&lt;div itemscope
+  itemtype="http://www.w3.org/ns/activitystreams#Connection">
+  &lt;span itemprop="a" itemscope
+    itemtype="http://www.w3.org/ns/activitystreams#Person">
+    &lt;span itemprop="displayName">Sally&lt;/span>
+  &lt;/span>
+  is connected to
+  &lt;span itemprop="b" itemscope
+    itemtype="http://www.w3.org/ns/activitystreams#Person">
+    &lt;span itemprop="displayName">John&lt;/span>
+  &lt;/span>
+&lt;/div></pre>
+  </div>
+  <div id="ex22c-rdfa" style="display:none;">
+<pre class="example highlight html"
+>&lt;div vocab="http://www.w3.org/ns/activitystreams#"
+  typeof="Connection">
+  &lt;span property="a" typeof="Person">
+    &lt;span property="displayName">Sally&lt;/span>
+  &lt;/span>
+  is connected to
+  &lt;span property="b" typeof="Person">
+    &lt;span property="displayName">John&lt;/span>
+  &lt;/span>
+&lt;/div></pre>
+  </div>
+  <div id="ex22c-microformats" style="display:none;">
+<pre class="example highlight html"
+>&lt;div class="h-as-connection">
+  &lt;span class="h-card">
+    &lt;span class="p-name">Sally&lt;/span>
+  &lt;/span>
+  is connected to
+  &lt;span class="h-card">
+    &lt;span class="p-name">John&lt;/span>
+  &lt;/span>
+&lt;/div></pre>
+  </div>
+<div id="ex22c-turtle" style="display: none;">
+<pre class="example highlight turtle">
+@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
+
+_:b0 a as:Connection ;
+  as:relationship <http://example.org/relationship/knows>;
+  as:a [
+    a as:Person ;
+      as:displayName "Sally" .
+  ] ;
+  as:b [
+    a as:Person ;
+      as:displayName "John" .
+  ] .</pre>
+  </div>
+</div>
+</td>
+        </tr>
+        <tr>
+          <td >Notes:</td>
+          <td >
+            On a <code><a>Connection</a></code> object, the
+            <code>relationship</code> property identifies the kind of
+            relationship that exists between
+            <code><a title="a-term">a</a></code> and
+            <code><a title="b-term">b</a></code>.
+
+          </td>
+        </tr>
+        <tr>
+          <td >Domain:</td>
+          <td ><code><a>Connection</a></code></td>
+        </tr>
+        <tr>
+          <td >Range:</td>
+          <td ><code><a>Object</a></code></td>
         </tr>
       </tbody>
 
@@ -17846,20 +17972,29 @@ _:b0 a as:Connection ;
     rdfs:label "a"@en;
     rdfs:comment "On a Connection object, identifies the subject. e.g. when saying \"John is connected to Sally\", 'a' refers to 'John'"@en ;
     rdfs:domain as:Connection ;
+    rdfs:subPropertyOf rdf:subject ;
     rdfs:range [
       a owl:Class ;
       owl:unionOf ( as:Link as:Object )
-    ];
+    ].
 
   as:b a owl:FunctionalProperty,
          owl:ObjectProperty;
     rdfs:label "b"@en;
     rdfs:comment "On a Connection object, identifies the object. e.g. when saying \"John is connected to Sally\", 'b' refers to 'Sally'"@en ;
     rdfs:domain as:Connection ;
+    rdfs:subPropertyOf rdf:object ;
     rdfs:range [
       a owl:Class ;
       owl:unionOf ( as:Link as:Object )
-    ];
+    ].
+
+  as:relationship a owl:ObjectProperty;
+    rdfs:label "relationship"@en;
+    rdfs:comment "On a Connection object, describes the type of relationship"@en;
+    rdfs:subPropertyOf rdf:predicate ;
+    rdfs:domain as:Connection ;
+    rdfs:range rdf:Property ;
 
   #################################################################
   #
@@ -18241,7 +18376,7 @@ _:b0 a as:Connection ;
     rdfs:subClassOf as:Respond ;
     rdfs:comment "The actor is confirming the object"@en .
 
-  as:Connection a owl:Class ;
+  as:Connection a owl:Class, rdf:Statement ;
     rdfs:label "Connection"@en ;
     rdfs:subClassOf as:Object ;
     rdfs:comment "Represents a Social Graph connection between two Individuals (indicated by the 'a' and 'b' properties)"@en .

--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -1443,7 +1443,6 @@ _:b0 a as:Object ;
           <code><a href="activitystreams2-vocabulary.html#dfn-displayname">displayNameMap</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-hreflang">hreflang</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-mediatype">mediaType</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-rel">rel</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-title">title</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-title">titleMap</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-height">height</a></code> |
@@ -1678,20 +1677,12 @@ _:b0 a as:Object ;
       </p>
 
       <p>
-        RFC 5988 defines that all Links have a "link relation" that describes
-        the contextual purpose of the link.  Within a <a>Link</a>,
-        the <code><a href="activitystreams2-vocabulary.html#dfn-rel">rel</a></code> property
-        provides the link relation value. If no <code>rel</code> property is
-        specified, the link relation is considered to be unspecified. Any given
-        Link can have multiple link relation values. In the JSON-LD serialization,
-        A single link relation is expressed as a single JSON string. Multiple
-        link relations are expressed as an array of JSON strings.
-      </p>
-
-      <p>
-        In the following example, two separate references are provided.  The link
-        relation of the first is unspecified, while the link relation of the
-        second is "<code>canonical</code>".
+        RFC 5988 defines that all Links have a link relation that describes
+        the contextual purpose of the link. Within an Activity Streams 2.0
+        document, the link relation is the JSON-LD expanded identifier of the
+        property whose value is a <a>Link</a>. For instance, in the following
+        example, two separate image references are provided. The link relation
+        for both is <code>http://www.w3.org/ns/activitystreams#image</code>.
       </p>
 
       <figure><figcaption></figcaption>
@@ -1714,8 +1705,7 @@ _:b0 a as:Object ;
     {
       "@type": "Link",
       "href": "http://example.org/application/123.png",
-      "mediaType": "image/png",
-      "rel": "canonical"
+      "mediaType": "image/png"
     }
   ]
 }</pre>
@@ -1726,12 +1716,13 @@ _:b0 a as:Object ;
   itemid="http://example.org/application/123">
   &lt;div itemprop="displayName">My Application&lt;/div>
   &lt;img itemprop="image"
-    src="http://example.org/application/123.gif" />
+    src="http://example.org/application/123.gif"
+    rel="http://www.w3.org/ns/acivitystreams#image" />
   &lt;img itemprop="image" itemscope
     itemtype="http://www.w3.org/ns/activitystreams#Link"
     type="image/png"
     src="http://example.org/application/123.png"
-    rel="canonical" />
+    rel="http://www.w3.org/ns/acivitystreams#image" />
 &lt;/div></pre></div>
   <div id="ex15-rdfa" style="display:none;">
 <pre class="example highlight html"
@@ -1739,11 +1730,12 @@ _:b0 a as:Object ;
   resource="http://example.org/application/123">
   &lt;div property="displayName">My Application&lt;/div>
   &lt;img property="image"
-    src="http://example.org/application/123.gif" />
+    src="http://example.org/application/123.gif"
+    rel="http://www.w3.org/ns/acivitystreams#image" />
   &lt;img property="image" typeof="Link"
     type="image/png"
     src="http://example.org/application/123.png"
-    rel="canonical" />
+    rel="http://www.w3.org/ns/acivitystreams#image" />
 &lt;/div></pre></div>
   <div id="ex15-microformats" style="display:none;">
 <pre class="example highlight html"
@@ -1751,10 +1743,11 @@ _:b0 a as:Object ;
   &lt;meta class="p-as-id" name="id" content="http://example.org/application/123">
   &lt;div class="p-name">My Application&lt;/div>
   &lt;img class="u-photo"
-    src="http://example.org/application/123.gif" />
+    src="http://example.org/application/123.gif"
+    rel="http://www.w3.org/ns/acivitystreams#image"/>
   &lt;img class="u-photo"
-       src="http://example.org/application/123.png"
-       rel="canonical" />
+    src="http://example.org/application/123.png"
+    rel="http://www.w3.org/ns/acivitystreams#image" />
 &lt;/div></pre></div>
   <div id="ex15-turtle" style="display:none;">
 <pre class="example highlight turtle"
@@ -1767,23 +1760,11 @@ _:b0 a as:Object ;
     [
       a as:Link ;
         as:href &lt;http://example.org/application/123.png&gt; ;
-        as:mediaType "image/png" ;
-        as:rel "canonical"
+        as:mediaType "image/png"
     ] .
 </pre></div>
 </div>
 </figure>
-
-      <p>
-        It ought to be noted that the [[!HTML5]] specification provides it's
-        own alternative definition of a "link relation" that differs slightly
-        from the [[RFC5988]] definition. In the HTML5 definition, any string
-        that does not contain the "space" U+0020, "tab" (U+0009), "LF" (U+000A),
-        "FF" (U+000C), "CR" (U+000D) or "," (U+002C) characters can be used as a
-        valid link relation. To promote interoperability, Activity Streams 2.0
-        implementations MUST only use link relations that are valid in terms of
-        both the [[RFC5988]] and [[HTML5]] definitions.
-      </p>
 
       <p>
         Note that the <a>Link</a> and <a>Object</a> classes are disjoint from one

--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -2084,7 +2084,7 @@ _:b0 a as:Share ;
       </p>
 
       <p>
-        In additional to common properties supported by all <a>Object</a>
+        In addition to common properties supported by all <a>Object</a>
         instances, <code>Activity</code> objects support the following additional
         properties defined by the <a href="activitystreams2-vocabulary.html">Vocabulary</a>:
           <code><a href="activitystreams2-vocabulary.html#dfn-actor">actor</a></code> |

--- a/activitystreams2.owl
+++ b/activitystreams2.owl
@@ -343,20 +343,29 @@ as:a a owl:FunctionalProperty,
   rdfs:label "a"@en;
   rdfs:comment "On a Connection object, identifies the subject. e.g. when saying \"John is connected to Sally\", 'a' refers to 'John'"@en ;
   rdfs:domain as:Connection ;
+  rdfs:subPropertyOf rdf:subject ;
   rdfs:range [
     a owl:Class ;
     owl:unionOf ( as:Link as:Object )
-  ];
+  ].
 
 as:b a owl:FunctionalProperty,
        owl:ObjectProperty;
   rdfs:label "b"@en;
   rdfs:comment "On a Connection object, identifies the object. e.g. when saying \"John is connected to Sally\", 'b' refers to 'Sally'"@en ;
   rdfs:domain as:Connection ;
+  rdfs:subPropertyOf rdf:object ;
   rdfs:range [
     a owl:Class ;
     owl:unionOf ( as:Link as:Object )
-  ];
+  ].
+
+as:relationship a owl:ObjectProperty;
+  rdfs:label "relationship"@en;
+  rdfs:comment "On a Connection object, describes the type of relationship"@en;
+  rdfs:subPropertyOf rdf:predicate ;
+  rdfs:domain as:Connection ;
+  rdfs:range rdf:Property ;
 
 #################################################################
 #
@@ -738,7 +747,7 @@ as:Confirm a owl:Class ;
   rdfs:subClassOf as:Respond ;
   rdfs:comment "The actor is confirming the object"@en .
 
-as:Connection a owl:Class ;
+as:Connection a owl:Class, rdf:Statement ;
   rdfs:label "Connection"@en ;
   rdfs:subClassOf as:Object ;
   rdfs:comment "Represents a Social Graph connection between two Individuals (indicated by the 'a' and 'b' properties)"@en .

--- a/activitystreams2.owl
+++ b/activitystreams2.owl
@@ -554,12 +554,6 @@ as:rating a owl:DatatypeProperty ,
       [ xsd:maxInclusive "5.0"^^xsd:float ]
     )] .
 
-as:rel a owl:DatatypeProperty ;
-  rdfs:label "rel"@en ;
-  rdfs:comment "The RFC 5988 or HTML5 Link Relation associated with the Link"@en ;
-  rdfs:range xsd:string ;
-  rdfs:domain as:Link .
-
 as:startIndex a owl:DatatypeProperty ,
         owl:FunctionalProperty ;
   rdfs:label "startIndex"@en ;


### PR DESCRIPTION
Per the recent discussions about as:Link, I propose removing
the `rel` property from as:Link. It's been pointed out that there
are modeling issues in terms of how the rel property semantically
relates to the property name. This simplifies things by eliminating
the potential conflict.