### PR TITLE
Simplify audience targeting

### DIFF
--- a/activitystreams2-context.jsonld
+++ b/activitystreams2-context.jsonld
@@ -112,10 +112,6 @@
       "@id": "as:bcc",
       "@type": "@id"
     },
-    "bto": {
-      "@id": "as:bto",
-      "@type": "@id"
-    },
     "cc": {
       "@id": "as:cc",
       "@type": "@id"
@@ -223,10 +219,6 @@
     },
     "target": {
       "@id": "as:target",
-      "@type": "@id"
-    },
-    "to": {
-      "@id": "as:to",
       "@type": "@id"
     },
     "url": {

--- a/activitystreams2-vocabulary.html
+++ b/activitystreams2-vocabulary.html
@@ -6212,6 +6212,7 @@ _:b0 a as:Service ;
     "@type": "Person",
     "displayName": "Sally"
   },
+  "relationship": "http://example.org/relationship/knows",
   "b": {
     "@type": "Person",
     "displayName": "John"
@@ -6226,7 +6227,10 @@ _:b0 a as:Service ;
     itemtype="http://www.w3.org/ns/activitystreams#Person">
     &lt;span itemprop="displayName">Sally&lt;/span>
   &lt;/span>
-  is connected to
+  &lt;span itemprop="relationship"
+    itemid="http://example.org/relationship/knows">
+    knows
+  &lt;/span>
   &lt;span itemprop="b" itemscope
     itemtype="http://www.w3.org/ns/activitystreams#Person">
     &lt;span itemprop="displayName">John&lt;/span>
@@ -6240,7 +6244,10 @@ _:b0 a as:Service ;
   &lt;span property="a" typeof="Person">
     &lt;span property="displayName">Sally&lt;/span>
   &lt;/span>
-  is connected to
+  &lt;span property="relationship"
+    resource="http://example.org/relationship/knows">
+    knows
+  &lt;/span>
   &lt;span property="b" typeof="Person">
     &lt;span property="displayName">John&lt;/span>
   &lt;/span>
@@ -6252,7 +6259,7 @@ _:b0 a as:Service ;
   &lt;span class="h-card">
     &lt;span class="p-name">Sally&lt;/span>
   &lt;/span>
-  is connected to
+  knows
   &lt;span class="h-card">
     &lt;span class="p-name">John&lt;/span>
   &lt;/span>
@@ -6263,6 +6270,7 @@ _:b0 a as:Service ;
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 
 _:b0 a as:Connection ;
+  as:relationship <http://example.org/relationship/knows> ;
   as:a [
     a as:Person ;
       as:displayName "Sally" .
@@ -6288,7 +6296,8 @@ _:b0 a as:Connection ;
             <td>Properties:</td>
             <td>
               <p><code><a title="a-term">a</a></code> |
-              <code title="b-term"><a title="b-term">b</a></code></p>
+              <code><a title="b-term">b</a></code> |
+              <code><a>relationship</a></code></p>
               <p>Inherits all properties from <code><a>Object</a></code>.</p>
             </td>
           </tr>
@@ -8121,7 +8130,8 @@ _:b0 a as:Mention ;
       <code><a>updated</a></code> |
       <code><a>width</a></code> |
       <code><a title="a-term">a</a></code> |
-      <code><a title="b-term">b</a></code>
+      <code><a title="b-term">b</a></code> |
+      <code><a>relationship</a></code>
     </p>
 
     <p>
@@ -16925,6 +16935,7 @@ _:b0 a as:Content ;
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 
 _:b0 a as:Connection ;
+  as:relationship <http://example.org/relationship/knows>;
   as:a [
     a as:Person ;
       as:displayName "Sally" .
@@ -16982,6 +16993,7 @@ _:b0 a as:Connection ;
     "@type": "Person",
     "displayName": "Sally"
   },
+  "relationship": "http://example.org/relationship/knows",
   "b": {
     "@type": "Person",
     "displayName": "John"
@@ -16996,7 +17008,10 @@ _:b0 a as:Connection ;
     itemtype="http://www.w3.org/ns/activitystreams#Person">
     &lt;span itemprop="displayName">Sally&lt;/span>
   &lt;/span>
-  is connected to
+  &lt;span itemprop="relationship"
+    itemid="http://example.org/relationship/knows">
+    knows
+  &lt;/span>
   &lt;span itemprop="b" itemscope
     itemtype="http://www.w3.org/ns/activitystreams#Person">
     &lt;span itemprop="displayName">John&lt;/span>
@@ -17010,7 +17025,10 @@ _:b0 a as:Connection ;
   &lt;span property="a" typeof="Person">
     &lt;span property="displayName">Sally&lt;/span>
   &lt;/span>
-  is connected to
+  &lt;span property="relationship"
+    resource="http://example.org/relationship/knows">
+    knows
+  &lt;/span>
   &lt;span property="b" typeof="Person">
     &lt;span property="displayName">John&lt;/span>
   &lt;/span>
@@ -17022,7 +17040,7 @@ _:b0 a as:Connection ;
   &lt;span class="h-card">
     &lt;span class="p-name">Sally&lt;/span>
   &lt;/span>
-  is connected to
+  knows
   &lt;span class="h-card">
     &lt;span class="p-name">John&lt;/span>
   &lt;/span>
@@ -17033,6 +17051,7 @@ _:b0 a as:Connection ;
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 
 _:b0 a as:Connection ;
+  as:relationship <http://example.org/relationship/knows>;
   as:a [
     a as:Person ;
       as:displayName "Sally" .
@@ -17313,6 +17332,113 @@ _:b0 a as:Connection ;
         <tr>
           <td >Equivalent To:</td>
           <td ><code><a>attachment</a></code></td>
+        </tr>
+      </tbody>
+
+      <tbody>
+        <tr>
+          <td rowspan="5" ><dfn title="relationship">relationship</dfn></td>
+          <td  style="width: 10%">URI:</td>
+          <td ><code>http://www.w3.org/ns/activitystreams#relationship</code></td>
+          <td rowspan="5">
+            <div class="nanotabs">
+              <ul>
+                <li><a href="#ex22c-jsonld" class="selected">JSON-LD</a></li>
+                <li><a href="#ex22c-microdata" class="selected">Microdata</a></li>
+                <li><a href="#ex22c-rdfa" class="selected">RDFa</a></li>
+                <li><a href="#ex22c-microformats" class="selected">Microformats</a></li>
+                <li><a href="#ex22c-turtle" class="selected">Turtle</a></li>
+              </ul>
+              <div id="ex22c-jsonld" style="display: block;">
+            <pre class="example highlight json">{
+  "@context": "http://www.w3.org/ns/activitystreams",
+  "@type": "Connection",
+  "a": {
+    "@type": "Person",
+    "displayName": "Sally"
+  },
+  "b": {
+    "@type": "Person",
+    "displayName": "John"
+  }
+}</pre>
+</div>
+<div id="ex22c-microdata" style="display:none;">
+<pre class="example highlight html"
+>&lt;div itemscope
+  itemtype="http://www.w3.org/ns/activitystreams#Connection">
+  &lt;span itemprop="a" itemscope
+    itemtype="http://www.w3.org/ns/activitystreams#Person">
+    &lt;span itemprop="displayName">Sally&lt;/span>
+  &lt;/span>
+  is connected to
+  &lt;span itemprop="b" itemscope
+    itemtype="http://www.w3.org/ns/activitystreams#Person">
+    &lt;span itemprop="displayName">John&lt;/span>
+  &lt;/span>
+&lt;/div></pre>
+  </div>
+  <div id="ex22c-rdfa" style="display:none;">
+<pre class="example highlight html"
+>&lt;div vocab="http://www.w3.org/ns/activitystreams#"
+  typeof="Connection">
+  &lt;span property="a" typeof="Person">
+    &lt;span property="displayName">Sally&lt;/span>
+  &lt;/span>
+  is connected to
+  &lt;span property="b" typeof="Person">
+    &lt;span property="displayName">John&lt;/span>
+  &lt;/span>
+&lt;/div></pre>
+  </div>
+  <div id="ex22c-microformats" style="display:none;">
+<pre class="example highlight html"
+>&lt;div class="h-as-connection">
+  &lt;span class="h-card">
+    &lt;span class="p-name">Sally&lt;/span>
+  &lt;/span>
+  is connected to
+  &lt;span class="h-card">
+    &lt;span class="p-name">John&lt;/span>
+  &lt;/span>
+&lt;/div></pre>
+  </div>
+<div id="ex22c-turtle" style="display: none;">
+<pre class="example highlight turtle">
+@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
+
+_:b0 a as:Connection ;
+  as:relationship <http://example.org/relationship/knows>;
+  as:a [
+    a as:Person ;
+      as:displayName "Sally" .
+  ] ;
+  as:b [
+    a as:Person ;
+      as:displayName "John" .
+  ] .</pre>
+  </div>
+</div>
+</td>
+        </tr>
+        <tr>
+          <td >Notes:</td>
+          <td >
+            On a <code><a>Connection</a></code> object, the
+            <code>relationship</code> property identifies the kind of
+            relationship that exists between
+            <code><a title="a-term">a</a></code> and
+            <code><a title="b-term">b</a></code>.
+
+          </td>
+        </tr>
+        <tr>
+          <td >Domain:</td>
+          <td ><code><a>Connection</a></code></td>
+        </tr>
+        <tr>
+          <td >Range:</td>
+          <td ><code><a>Object</a></code></td>
         </tr>
       </tbody>
 
@@ -17663,20 +17789,29 @@ _:b0 a as:Connection ;
     rdfs:label "a"@en;
     rdfs:comment "On a Connection object, identifies the subject. e.g. when saying \"John is connected to Sally\", 'a' refers to 'John'"@en ;
     rdfs:domain as:Connection ;
+    rdfs:subPropertyOf rdf:subject ;
     rdfs:range [
       a owl:Class ;
       owl:unionOf ( as:Link as:Object )
-    ];
+    ].
 
   as:b a owl:FunctionalProperty,
          owl:ObjectProperty;
     rdfs:label "b"@en;
     rdfs:comment "On a Connection object, identifies the object. e.g. when saying \"John is connected to Sally\", 'b' refers to 'Sally'"@en ;
     rdfs:domain as:Connection ;
+    rdfs:subPropertyOf rdf:object ;
     rdfs:range [
       a owl:Class ;
       owl:unionOf ( as:Link as:Object )
-    ];
+    ].
+
+  as:relationship a owl:ObjectProperty;
+    rdfs:label "relationship"@en;
+    rdfs:comment "On a Connection object, describes the type of relationship"@en;
+    rdfs:subPropertyOf rdf:predicate ;
+    rdfs:domain as:Connection ;
+    rdfs:range rdf:Property ;
 
   #################################################################
   #
@@ -18064,7 +18199,7 @@ _:b0 a as:Connection ;
     rdfs:subClassOf as:Respond ;
     rdfs:comment "The actor is confirming the object"@en .
 
-  as:Connection a owl:Class ;
+  as:Connection a owl:Class, rdf:Statement ;
     rdfs:label "Connection"@en ;
     rdfs:subClassOf as:Object ;
     rdfs:comment "Represents a Social Graph connection between two Individuals (indicated by the 'a' and 'b' properties)"@en .

--- a/activitystreams2-vocabulary.html
+++ b/activitystreams2-vocabulary.html
@@ -304,7 +304,9 @@
               <code><a title="tag-term">tag</a></code> |
               <code><a>title</a></code> |
               <code><a>updated</a></code> |
-              <code><a>url</a></code>
+              <code><a>url</a></code> |
+              <code><a>cc</a></code> |
+              <code><a>bcc</a></code>
             </p>
           </td>
         </tr>
@@ -522,11 +524,7 @@ _:b0 a as:Activity ;
               <code><a>target</a></code> |
               <code><a>result</a></code> |
               <code><a>origin</a></code> |
-              <code><a>priority</a></code> |
-              <code><a>to</a></code> |
-              <code><a>bto</a></code> |
-              <code><a>cc</a></code> |
-              <code><a>bcc</a></code>
+              <code><a>priority</a></code>
             </p>
 
             <p>
@@ -8070,7 +8068,6 @@ _:b0 a as:Mention ;
       <code><a>attachment</a></code> |
       <code><a>attributedTo</a></code> |
       <code><a>bcc</a></code> |
-      <code><a>bto</a></code> |
       <code><a>cc</a></code> |
       <code><a>context</a></code> |
       <code><a>current</a></code> |
@@ -8095,7 +8092,6 @@ _:b0 a as:Mention ;
       <code><a>self</a></code> |
       <code><a title="tag-term">tag</a></code> |
       <code><a>target</a></code> |
-      <code><a>to</a></code> |
       <code><a>url</a></code> |
       <code><a>accuracy</a></code> |
       <code><a>alias</a></code> |
@@ -8820,139 +8816,13 @@ _:b0 a as:Share ;
         <tr>
           <td>Notes:</td>
           <td>
-            Identifies one or more Actors that are part of the private secondary audience
-            of this Activity.
+            Identifies one or more Actors that are part of the private audience
+            of the Object.
           </td>
         </tr>
         <tr>
           <td >Domain:</td>
-          <td ><code><a>Activity</a></code></td>
-        </tr>
-        <tr>
-          <td >Range:</td>
-          <td ><code><a>Actor</a></code> | <code><a>Link</a></code></td>
-        </tr>
-      </tbody>
-
-      <tbody>
-        <tr>
-          <td rowspan="4" ><dfn>bto</dfn></td>
-          <td  style="width: 10%">URI:</td>
-          <td ><code>http://www.w3.org/ns/activitystreams#bto</code></td>
-          <td rowspan="4">
-<div class="nanotabs">
-  <ul>
-    <li><a href="#ex69-jsonld" class="selected">JSON-LD</a></li>
-    <li><a href="#ex69-microdata" class="selected">Microdata</a></li>
-    <li><a href="#ex69-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex69-microformats" class="selected">Microformats</a></li>
-    <li><a href="#ex69-turtle" class="selected">Turtle</a></li>
-  </ul>
-  <div id="ex69-jsonld" style="display: block;">
-<pre class="example highlight json">{
-  "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
-  "actor": "acct:sally@example.org",
-  "object": "http://example.org/posts/1",
-  "target": "acct:john@example.org",
-  "bto": [ "acct:joe@example.org" ]
-}</pre>
-  </div>
-  <div id="ex69-microdata" style="display: none;">
-<pre class="example highlight html"
->&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
-  &lt;link itemprop="actor"
-    href="acct:sally@example.org">
-    Sally
-  &lt;/link>
-  shared
-  &lt;a itemprop="object"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link itemprop="target"
-    href="acct:john@example.org">
-    John
-  &lt;/link>
-  (bto: &lt;link itemprop="bto"
-    href="acct:joe@example.org">
-    John
-  &lt;/link>)
-&lt;/div></pre>
-  </div>
-  <div id="ex69-rdfa" style="display: none;">
-<pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
-  &lt;link property="actor"
-    href="acct:sally@example.org">
-    Sally
-  &lt;/link>
-  shared
-  &lt;a property="object"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link property="target"
-    href="acct:john@example.org">
-    John
-  &lt;/link>
-  (bto: &lt;link property="bto"
-    href="acct:joe@example.org">
-    John
-  &lt;/link>)
-&lt;/div></pre>
-  </div>
-  <div id="ex69-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">
-      Sally
-  &lt;link>
-  shared
-  &lt;a class="u-share-of"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link class="u-as-target"
-    href="acct:sally@example.org">
-      John
-  &lt;link>
-  (bto: &lt;link class="u-as-bto"
-    href="acct:joe@example.org">
-    John
-  &lt;/link>)
-&lt;/div></pre>
-  </div>
-  <div id="ex69-turtle" style="display: none;">
-<pre class="example highlight turtle"
->@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
-
-_:b0 a as:Share ;
-  as:actor &lt;acct:sally@example.org&gt; ;
-  as:object &lt;http://example.org/posts/1&gt; ;
-  as:target &lt;acct:john@example.org&gt; ;
-  as:bto &lt;acct:joe@example.org&gt; .
-</pre>
-  </div>
-</div>
-        </td>
-        </tr>
-        <tr>
-          <td>Notes:</td>
-          <td>
-            Identifies an Actor that is part of the private primary audience
-            of this Activity.
-          </td>
-        </tr>
-        <tr>
-          <td >Domain:</td>
-          <td ><code><a>Activity</a></code></td>
+          <td ><code><a>Object</a></code></td>
         </tr>
         <tr>
           <td >Range:</td>
@@ -9072,13 +8942,13 @@ _:b0 a as:Share ;
         <tr>
           <td>Notes:</td>
           <td>
-            Identifies an Actor that is part of the public secondary audience
-            of this Activity.
+            Identifies an Actor that is part of the public audience
+            of the object.
           </td>
         </tr>
         <tr>
           <td >Domain:</td>
-          <td ><code><a>Activity</a></code></td>
+          <td ><code><a>Object</a></code></td>
         </tr>
         <tr>
           <td >Range:</td>
@@ -13534,130 +13404,6 @@ _:b0 a as:Share ;
 
       <tbody>
         <tr>
-          <td rowspan="4" ><dfn>to</dfn></td>
-          <td  style="width: 10%">URI:</td>
-          <td ><code>http://www.w3.org/ns/activitystreams#to</code></td>
-          <td rowspan="4">
-<div class="nanotabs">
-  <ul>
-    <li><a href="#ex123-jsonld" class="selected">JSON-LD</a></li>
-    <li><a href="#ex123-microdata" class="selected">Microdata</a></li>
-    <li><a href="#ex123-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex123-microformats" class="selected">Microformats</a></li>
-    <li><a href="#ex123-turtle" class="selected">Turtle</a></li>
-  </ul>
-  <div id="ex123-jsonld" style="display: block;">
-<pre class="example highlight json">{
-  "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
-  "actor": "acct:sally@example.org",
-  "object": "http://example.org/posts/1",
-  "target": "acct:john@example.org",
-  "to": [ "acct:joe@example.org" ]
-}</pre>
-  </div>
-  <div id="ex123-microdata" style="display: none;">
-<pre class="example highlight html"
->&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
-  &lt;link itemprop="actor"
-    href="acct:sally@example.org">
-    Sally
-  &lt;/link>
-  shared
-  &lt;a itemprop="object"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link itemprop="target"
-    href="acct:john@example.org">
-    John
-  &lt;/link>
-  (to: &lt;link itemprop="to"
-    href="acct:joe@example.org">
-    John
-  &lt;/link>)
-&lt;/div></pre>
-  </div>
-  <div id="ex123-rdfa" style="display: none;">
-<pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
-  &lt;link property="actor"
-    href="acct:sally@example.org">
-    Sally
-  &lt;/link>
-  shared
-  &lt;a property="object"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link property="target"
-    href="acct:john@example.org">
-    John
-  &lt;/link>
-  (to: &lt;link property="to"
-    href="acct:joe@example.org">
-    John
-  &lt;/link>)
-&lt;/div></pre>
-  </div>
-  <div id="ex123-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;link class="u-author
-    href="acct:sally@example.org">Sally&lt;link>
-  shared
-  &lt;a class="u-share-of"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link class="u-as-target"
-    href="acct:sally@example.org">
-      John
-  &lt;link>
-  (to: &lt;link class="u-as-to"
-    href="acct:joe@example.org">
-    John
-  &lt;/link>)
-&lt;/div></pre>
-  </div>
-  <div id="ex123-turtle" style="display: none;">
-<pre class="example highlight turtle"
->@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt .
-
-_:b0 a as:Share ;
-  as:actor &lt;acct:sally@example.org&gt; ;
-  as:object &lt;http://example.org/posts/1&gt; ;
-  as:target &lt;acct:john@example.org&gt; ;
-  as:to &lt;acct:joe@example.org&gt; .
-</pre>
-  </div>
-</div>
-          </td>
-        </tr>
-        <tr>
-          <td>Notes:</td>
-          <td>
-            Identifies an entity considered to be part of the public primary
-            audience of an Activity
-          </td>
-        </tr>
-        <tr>
-          <td >Domain:</td>
-          <td ><code><a>Activity</a></code></td>
-        </tr>
-        <tr>
-          <td >Range:</td>
-          <td ><code><a>Object</a></code> | <code><a>Link</a></code></td>
-        </tr>
-      </tbody>
-
-      <tbody>
-        <tr>
           <td rowspan="4" ><dfn>url</dfn></td>
           <td  style="width: 10%">URI:</td>
           <td ><code>http://www.w3.org/ns/activitystreams#url</code></td>
@@ -17660,15 +17406,7 @@ _:b0 a as:Connection ;
 
   as:bcc a owl:ObjectProperty ;
     rdfs:label "bcc"@en ;
-    rdfs:domain as:Activity ;
-    rdfs:range [
-      a owl:Class ;
-      owl:unionOf ( as:Actor as:Link )
-    ] .
-
-  as:bto a owl:ObjectProperty ;
-    rdfs:label "bto"@en ;
-    rdfs:domain as:Activity ;
+    rdfs:domain as:Object ;
     rdfs:range [
       a owl:Class ;
       owl:unionOf ( as:Actor as:Link )
@@ -17676,7 +17414,7 @@ _:b0 a as:Connection ;
 
   as:cc a owl:ObjectProperty ;
     rdfs:label "cc"@en ;
-    rdfs:domain as:Activity ;
+    rdfs:domain as:Object ;
     rdfs:range [
       a owl:Class ;
       owl:unionOf ( as:Actor as:Link )
@@ -17909,14 +17647,6 @@ _:b0 a as:Connection ;
     rdfs:range [
       a owl:Class ;
       owl:unionOf ( as:Object as:Link )
-    ] .
-
-  as:to a owl:ObjectProperty ;
-    rdfs:label "to"@en ;
-    rdfs:domain as:Activity ;
-    rdfs:range [
-      a owl:Class ;
-      owl:unionOf ( as:Actor as:Link )
     ] .
 
   as:url a owl:ObjectProperty ;

--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -810,35 +810,35 @@ _:b0 a as:Collection ;
         using the JSON-LD <code>@type</code> keyword), all instances of the <code>Object</code>
         class share a common set of properties normatively defined by the
         <a href="activitystreams2-vocabulary.html">Activity Vocabulary</a>. These include:
-        <code>
-          <code><a href="activitystreams2-vocabulary.html#dfn-alias">alias</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-attachment">attachment</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-attributedto">attributedTo</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-content-term">content</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-context">context</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-content">contentMap</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-displayname">displayName</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-displayname">displayNameMap</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-endtime">endTime</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-generator">generator</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-icon">icon</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-image-term">image</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-inreplyto">inReplyTo</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-location">location</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-preview">preview</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-published">published</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-rating">rating</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-replies">replies</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-scope">scope</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-starttime">startTime</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-summary">summary</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-summary">summaryMap</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-tag">tag</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-title">title</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-title">titleMap</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-updated">updated</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-url">url</a></code>
-        </code>
+        <code><a href="activitystreams2-vocabulary.html#dfn-alias">alias</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-attachment">attachment</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-attributedto">attributedTo</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-content-term">content</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-context">context</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-content">contentMap</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-displayname">displayName</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-displayname">displayNameMap</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-endtime">endTime</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-generator">generator</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-icon">icon</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-image-term">image</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-inreplyto">inReplyTo</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-location">location</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-preview">preview</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-published">published</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-rating">rating</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-replies">replies</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-scope">scope</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-starttime">startTime</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-summary">summary</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-summary">summaryMap</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-tag">tag</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-title">title</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-title">titleMap</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-updated">updated</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-url">url</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-cc">cc</a></code> |
+        <code><a href="activitystreams2-vocabulary.html#dfn-bcc">bcc</a></code>
       </p>
 
       <p>
@@ -2111,11 +2111,7 @@ _:b0 a as:Share ;
           <code><a href="activitystreams2-vocabulary.html#dfn-target">target</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-origin">origin</a></code> |
           <code><a href="activitystreams2-vocabulary.html#dfn-result">result</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-priority">priority</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-to">to</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-bto">bto</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-cc">cc</a></code> |
-          <code><a href="activitystreams2-vocabulary.html#dfn-bcc">bcc</a></code>
+          <code><a href="activitystreams2-vocabulary.html#dfn-priority">priority</a></code>
       </p>
 
       <p>
@@ -2277,93 +2273,6 @@ _:b0 a as:Share ;
   as:object &lt;http://example.com/notes/1&gt; .</pre></div>
 </div>
 </figure>
-
-      <section id="audienceTargeting">
-
-        <h2>Audience Targeting</h2>
-
-        <p>
-          Conceptually, every Activity has both a Primary and Secondary audience.
-          The Primary audience consists of those entities either directly involved
-          in the performance of the activity or who "own" the objects involved.
-          The Secondary audience consists of the collection of entities sharing
-          an interest in the activity but who might not be directly involved (e.g.
-          "followers").
-        </p>
-
-        <p>
-          For instance, suppose a social network of three individuals: Bob, Joe
-          and Jane.  Bob and Joe are each friends with Jane but are not friends
-          with one another.  Bob has chosen to "follow" activities for which
-          Jane is directly involved.  Jane shares a file with Joe.
-        </p>
-
-        <p>
-          In this example, Jane and Joe are each directly involved in the file
-          sharing activity and together make up the Primary Audience for that
-          event.  Bob, having an interest in activities involving Jane, is the
-          Secondary Audience.  Knowing this, a system that produces or consumes
-          the activity can intelligently notify each person of the event.
-        </p>
-
-        <p>
-          While there are means (based on the action type, actor, object and
-          target of the activity) to infer the primary audience for many types of
-          activities, heuristics do not work in every case and do not provide a
-          means of identifying the secondary audience.  The
-          <code><a href="activitystreams2-vocabulary.html#dfn-to">to</a></code>,
-          <code><a href="activitystreams2-vocabulary.html#dfn-cc">cc</a></code>,
-          <code><a href="activitystreams2-vocabulary.html#dfn-bto">bto</a></code> and
-          <code><a href="activitystreams2-vocabulary.html#dfn-bcc">bcc</a></code>
-          properties MAY be used within an Activity to explicitly identify the
-          Primary and Secondary audiences.
-        </p>
-
-        <p>
-          The prototypical use case for an Activity containing these properties
-          is the publication and redistribution of Activities through an
-          intermediary.  That is, an event source generates the activity and
-          publishes it to the intermediary which determines a subset of events
-          to display to specific individual users or groups.  Such a
-          determination can be made, in part, by identifying the Primary and
-          Secondary Audiences for each activity.
-        </p>
-
-        <p>
-          When the event source generates the activity and specifies values for
-          the <code>to</code> and <code>cc</code> fields, the
-          intermediary SHOULD redistribute that event
-          with the values of those fields intact, allowing any processor to see
-          who the activity has been targeted to.  This is precisely the same
-          model used by the <code>to</code> and <code>cc</code> fields in email
-          systems.
-        </p>
-
-        <p>
-          There are situations, however, in which disclosing the identity of
-          specific members of the audience may be inappropriate.  For instance,
-          a user may not wish to let other users know that they are interested
-          in various topics, individuals or types of events.  To support this
-          option, an event source generating an activity MAY use the
-          <code>bto</code> and <code>bcc</code> properties to list
-          entities to whom the activity should be privately targeted.  When an
-          intermediary receives an activity containing these properties, it
-          MUST remove those values prior to redistributing the activity.  The
-          intent is that systems MUST consider entities listed within the
-          <code>bto</code> and <code>bcc</code> properties as
-          part of the Primary and Secondary audience but MUST NOT disclose that
-          fact to any other party.
-        </p>
-
-        <p>
-          Audience targeting information included within an Activity only
-          describes the intent of the activity creator.  With clear exception
-          given to the appropriate handling of <code>bto</code> and
-          <code>bcc</code>, this specification leaves it up to implementations
-          to determine how the audience targeting information is used.
-        </p>
-
-      </section>
 
     </section>
 
@@ -3015,6 +2924,55 @@ _:c14n0 a gsp:Geometry ;
 
   </section>
 
+  <section id="audienceTargeting">
+
+    <h2>Audience Targeting</h2>
+
+    <p>
+      The <code><a href="activitystreams2-vocabulary.html#dfn-cc">cc</a></code>
+      and <code><a href="activitystreams2-vocabulary.html#dfn-bcc">bcc</a></code> properties are used to explicitly identify an audience for an
+      <a>Object</a>. Implementations that understand audience targeting can
+      use these properties to intelligently send notifications whenever
+      certain activities occur.
+    </p>
+
+    <p>
+      The prototypical use case for an Activity containing these properties
+      is the publication and redistribution of Activities through an
+      intermediary.  That is, an event source generates the activity and
+      publishes it to the intermediary which determines a subset of events
+      to display to specific individual users or groups.
+    </p>
+
+    <p>
+      When the event source generates the object and specifies values for
+      the <code>cc</code> property, the intermediary SHOULD redistribute
+      that event with the values of those properties intact, allowing any
+      processor to see to whom the object has been targeted.
+    </p>
+
+    <p>
+      There are situations, however, in which disclosing the identity of
+      specific members of the audience may be inappropriate.  For instance,
+      a user may not wish to let other users know that they are interested
+      in various topics, individuals or types of events.  To support this
+      option, an event source generating an activity MAY use the
+      <code>bcc</code> property to list entities to whom the activity
+      should be privately targeted.  When an intermediary receives an
+      object containing values for this property, it MUST remove those
+      values prior to redistributing the activity.
+    </p>
+
+    <p>
+      Audience targeting information included within an Object only
+      describes the intent of the object creator.  With clear exception
+      given to the appropriate handling of <code>bcc</code>, this
+      specification leaves it up to implementations to determine how the
+      audience targeting information is used.
+    </p>
+
+  </section>
+
   <section id="microsyntaxes">
     <h2>Mentions, Tags and Other Common Social Microsyntaxes</h2>
 
@@ -3052,8 +3010,8 @@ _:c14n0 a gsp:Geometry ;
       below:
     </p>
 
-    <figure><figcaption>A simple note with a mention an a hashtag:</figcaption>
-<pre> "Thank you @sally for all your hard work! #givingthanks" </pre></figure>
+    <figure><figcaption>A simple note with a mention and a hashtag:</figcaption>
+<pre class="example"> "Thank you @sally for all your hard work! #givingthanks" </pre></figure>
 
     <p>
       A typical social software implementation would typically render such a
@@ -3070,11 +3028,11 @@ _:c14n0 a gsp:Geometry ;
     </p>
 
     <figure><figcaption>Mentions and Tags within an Activity Streams Note</figcaption>
-<pre>{
+<pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
   "@type": "Note",
   "content": "Thank you @sally for all your hard work! #givingthanks",
-  "to": {
+  "cc": {
     "@type": "Person",
     "@id": "http://example.org/people/sally",
     "alias": "@sally"
@@ -3087,7 +3045,7 @@ _:c14n0 a gsp:Geometry ;
 
     <p>
       The <code>to</code> property indicates that the user "@sally" is
-      to be considered part of the <a href="#audienceTargeting">primary audience</a>
+      to be considered part of the <a href="#audienceTargeting">audience</a>
       of the note and should therefore receive notification. The <code>tag</code>
       property associates the Note with a reference to
       "<code>http://example.org/tags/givingthanks</code>". Note that the note's
@@ -3106,7 +3064,7 @@ _:c14n0 a gsp:Geometry ;
     </p>
 
     <figure><figcaption>Mentions and Tags within an Activity Streams Note</figcaption>
-<pre>{
+<pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
   "@type": "Note",
   "content": "Thank you @sally for all your hard work! #givingthanks",

--- a/activitystreams2.owl
+++ b/activitystreams2.owl
@@ -327,20 +327,29 @@ as:a a owl:FunctionalProperty,
   rdfs:label "a"@en;
   rdfs:comment "On a Connection object, identifies the subject. e.g. when saying \"John is connected to Sally\", 'a' refers to 'John'"@en ;
   rdfs:domain as:Connection ;
+  rdfs:subPropertyOf rdf:subject ;
   rdfs:range [
     a owl:Class ;
     owl:unionOf ( as:Link as:Object )
-  ];
+  ].
 
 as:b a owl:FunctionalProperty,
        owl:ObjectProperty;
   rdfs:label "b"@en;
   rdfs:comment "On a Connection object, identifies the object. e.g. when saying \"John is connected to Sally\", 'b' refers to 'Sally'"@en ;
   rdfs:domain as:Connection ;
+  rdfs:subPropertyOf rdf:object ;
   rdfs:range [
     a owl:Class ;
     owl:unionOf ( as:Link as:Object )
-  ];
+  ].
+
+as:relationship a owl:ObjectProperty;
+  rdfs:label "relationship"@en;
+  rdfs:comment "On a Connection object, describes the type of relationship"@en;
+  rdfs:subPropertyOf rdf:predicate ;
+  rdfs:domain as:Connection ;
+  rdfs:range rdf:Property ;
 
 #################################################################
 #
@@ -728,7 +737,7 @@ as:Confirm a owl:Class ;
   rdfs:subClassOf as:Respond ;
   rdfs:comment "The actor is confirming the object"@en .
 
-as:Connection a owl:Class ;
+as:Connection a owl:Class, rdf:Statement ;
   rdfs:label "Connection"@en ;
   rdfs:subClassOf as:Object ;
   rdfs:comment "Represents a Social Graph connection between two Individuals (indicated by the 'a' and 'b' properties)"@en .

--- a/activitystreams2.owl
+++ b/activitystreams2.owl
@@ -80,15 +80,7 @@ as:author a owl:ObjectProperty,
 
 as:bcc a owl:ObjectProperty ;
   rdfs:label "bcc"@en ;
-  rdfs:domain as:Activity ;
-  rdfs:range [
-    a owl:Class ;
-    owl:unionOf ( as:Actor as:Link )
-  ] .
-
-as:bto a owl:ObjectProperty ;
-  rdfs:label "bto"@en ;
-  rdfs:domain as:Activity ;
+  rdfs:domain as:Object ;
   rdfs:range [
     a owl:Class ;
     owl:unionOf ( as:Actor as:Link )
@@ -96,7 +88,7 @@ as:bto a owl:ObjectProperty ;
 
 as:cc a owl:ObjectProperty ;
   rdfs:label "cc"@en ;
-  rdfs:domain as:Activity ;
+  rdfs:domain as:Object ;
   rdfs:range [
     a owl:Class ;
     owl:unionOf ( as:Actor as:Link )
@@ -319,14 +311,6 @@ as:origin a owl:ObjectProperty ;
   rdfs:range [
     a owl:Class ;
     owl:unionOf ( as:Object as:Link )
-  ] .
-
-as:to a owl:ObjectProperty ;
-  rdfs:label "to"@en ;
-  rdfs:domain as:Activity ;
-  rdfs:range [
-    a owl:Class ;
-    owl:unionOf ( as:Actor as:Link )
   ] .
 
 as:url a owl:ObjectProperty ;


### PR DESCRIPTION
Remove the "to" and "bto" properties. Use "cc" and "bcc" only for
audience targeting. This gets rid of the notion of "primary" and
"secondary" audiences and simplifies the idea of audience targeting
in general. Also moves "cc" and "bcc" to the Object instead of
just Activity.