### PR TITLE
remove microformats examples

### DIFF
--- a/activitystreams2-vocabulary.html
+++ b/activitystreams2-vocabulary.html
@@ -177,7 +177,7 @@
 
       <p>
         Note that this document uses illustrative examples using JSON-LD,
-        Microdata, RDFa, Microformats and Turtle. Only the JSON-LD examples
+        Microdata, RDFa and Turtle. Only the JSON-LD examples
         are normative. The non-JSON-LD examples are strictly informational.
       </p>
 
@@ -225,7 +225,6 @@
     <li><a href="#ex1-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex1-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex1-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex1-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex1-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex1-jsonld" style="display: block;">
@@ -255,15 +254,6 @@
     A Simple, non-specific object
   &lt;/span&gt;
 &lt;/div&gt;</pre>
-  </div>
-  <div id="ex1-microformats" style="display: none;">
-    <pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;link class="p-name u-url"
-    href="urn:example:object:1">
-      A Simple, non-specific object
-  &lt;/link>
-&lt;/div></pre>
   </div>
   <div id="ex1-turtle" style="display: none;">
     <pre class="example highlight turtle"
@@ -335,7 +325,6 @@
     <li><a href="#ex2-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex2-microdata" class="selected ">Microdata</a></li>
     <li><a href="#ex2-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex2-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex2-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex2-jsonld" style="display: block;">
@@ -365,15 +354,6 @@
     hreflang="en"
     type="text/html"
     property="displayName">An example link&lt;/a></pre>
-  </div>
-  <div id="ex2-microformats" style="display: none;">
-<pre class="example highlight json"
->&lt;a class="h-entry u-url p-name"
-    href="http://example.org/abc"
-    hreflang="en"
-    type="text/html">
-    An example link
-&lt;/a></pre>
   </div>
   <div id="ex2-turtle" style="display: none;">
 <pre class="example highlight turtle"
@@ -436,7 +416,6 @@ _:b0 a as:Link ;
     <li><a href="#ex3-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex3-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex3-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex3-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex3-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex3-jsonld" style="display: block;">
@@ -480,18 +459,6 @@ _:b0 a as:Link ;
   did something to
   &lt;span typeof="Note" property="object">
     &lt;span property="displayName">A Note&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex3-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-activity">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  did something to
-  &lt;span class="p-item h-entry">
-    &lt;span class="p-name">A Note&lt;/span>
   &lt;/span>
 &lt;/div></pre>
   </div>
@@ -564,7 +531,6 @@ _:b0 a as:Activity ;
     <li><a href="#ex182-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex182-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex182-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex182-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex182-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex182-jsonld" style="display: block;">
@@ -609,18 +575,6 @@ _:b0 a as:Activity ;
   &lt;meta typeof="Place" property="target">
     &lt;meta property="displayName">Work&lt;/meta>
   &lt;/meta>
-&lt;/div></pre>
-  </div>
-  <div id="ex182-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-travel">
-  &lt;meta class="p-author h-card">
-    &lt;meta class="p-name">Sally&lt;/meta>
-  &lt;/meta>
-  is traveling to
-  &lt;span class="p-as-target h-geo">
-    &lt;span class="p-name">Work&lt;/span>
-  &lt;/span>
 &lt;/div></pre>
   </div>
   <div id="ex182-turtle" style="display: none;">
@@ -675,7 +629,6 @@ _:b0 a as:Travel ;
     <li><a href="#ex4-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex4-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex4-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex4-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex4-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex4-jsonld" style="display: block;">
@@ -696,12 +649,6 @@ _:b0 a as:Travel ;
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#"
   typeof=Actor"
   property="displayName">Sally&lt;/div></pre>
-  </div>
-  <div id="ex4-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-card">
-  &lt;span class="p-name">Sally&lt;/span>
-&lt;/div></pre>
   </div>
   <div id="ex4-turtle" style="display: none;">
 <pre class="example highlight turle"
@@ -745,7 +692,6 @@ _:b0 a as:Actor ;
     <li><a href="#ex5-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex5-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex5-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex5-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex5-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex5-jsonld" style="display: block;">
@@ -805,19 +751,6 @@ _:b0 a as:Actor ;
         Another Simple Note
       &lt;/span>
     &lt;/li>
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
-  <div id="ex5-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="2" /&lt;
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="2" /&gt;
-  &lt;ul class="p-as-items">
-    &lt;li class="h-entry p-name">A Simple Note&lt;/li>
-    &lt;li class="h-entry p-name">Another Simple Note&lt;/li>
   &lt;/ul>
 &lt;/div></pre>
   </div>
@@ -933,7 +866,6 @@ _:b0 a as:Collection ;
     <li><a href="#ex6-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex6-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex6-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex6-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex6-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex6-jsonld" style="display: block;">
@@ -996,21 +928,6 @@ _:b0 a as:Collection ;
         Another Simple Note
       &lt;/span>
     &lt;/li>
-  &lt;/ol>
-&lt;/div></pre>
-  </div>
-  <div id="ex6-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="2" /&lt;
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="2" /&gt;
-  &lt;meta class="p-as-start-index" name="startIndex"
-    content="0" /&gt;
-  &lt;ol class="p-as-items">
-    &lt;li class="h-entry p-name">A Simple Note&lt;/li>
-    &lt;li class="h-entry p-name">Another Simple Note&lt;/li>
   &lt;/ol>
 &lt;/div></pre>
   </div>
@@ -1187,7 +1104,6 @@ _:b0 a as:OrderedCollection ;
      <li><a href="#ex165-jsonld" class="selected">JSON-LD</a></li>
      <li><a href="#ex165-microdata" class="selected">Microdata</a></li>
      <li><a href="#ex165-rdfa" class="selected">RDFa</a></li>
-     <li><a href="#ex165-microformats" class="selected">Microformats</a></li>
      <li><a href="#ex165-turtle" class="selected">Turtle</a></li>
    </ul>
    <div id="ex165-jsonld" style="display: block;">
@@ -1246,23 +1162,6 @@ _:b0 a as:OrderedCollection ;
    &lt;/span>
  &lt;/div></pre>
    </div>
-   <div id="ex165-microformats" style="display:none;">
- <pre class="example highlight html"
- >&lt;div class="h-as-respond">
-   &lt;span class="p-author h-card">
-     &lt;span class="p-name">Sally&lt;/span>
-   &lt;/span>
-   responded to
-   &lt;a class="u-in-reply-to" href="http://example.org/posts/1">
-     "http://example.org/posts/1"
-   &lt;/a>
-   with
-   &lt;span class="p-as-result h-entry">
-     &lt;link class="u-in-reply-to" href="http://example.org/posts/1" />
-     "&lt;span class="e-content">This is a good article&lt;/span>"
-   &lt;/span>
- &lt;/div></pre>
-   </div>
  <div id="ex165-turtle" style="display: none;">
  <pre class="example highlight turtle">
  @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -1309,7 +1208,6 @@ _:b0 a as:OrderedCollection ;
     <li><a href="#ex7-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex7-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex7-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex7-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex7-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex7-jsonld" style="display: block;">
@@ -1377,25 +1275,6 @@ _:b0 a as:OrderedCollection ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex7-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-accept">
-  &lt;span class="p-author h-card" >
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;span>
-  accepted
-  &lt;span class="p-item h-as-invite">
-    &lt;link class="u-author"
-      href="acct:john@example.org">John's&lt;/link>
-      invitation to
-    &lt;span class="p-item h-event">
-      &lt;span class="p-name">
-        A Party!
-      &lt;/span>
-    &lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
   <div id="ex7-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -1449,7 +1328,6 @@ _:b0 a as:Accept ;
     <li><a href="#ex8-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex8-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex8-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex8-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex8-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex8-jsonld" style="display: block;">
@@ -1517,23 +1395,6 @@ _:b0 a as:Accept ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex8-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-tentativeaccept">
-  &lt;span class="p-author h-card" >
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;span>
-  tentatively accepted
-  &lt;span class="p-item h-as-invite">
-    &lt;link class="u-author"
-      href="acct:john@example.org">John's&lt;/link>
-      invitation to
-    &lt;span class="p-item h-event">
-      &lt;span class="p-name">A Party!&lt;/span>
-    &lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
   <div id="ex8-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -1582,7 +1443,6 @@ _:b0 a as:TentativeAccept ;
     <li><a href="#ex9-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex9-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex9-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex9-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex9-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex9-jsonld" style="display: block;">
@@ -1623,20 +1483,6 @@ _:b0 a as:TentativeAccept ;
     "http://example.org/abc"&lt;/a>
 &lt;/div></pre>
   </div>
-  <div id="ex9-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-add">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  added
-  &lt;span class="p-item h-entry">
-    &lt;a class="u-url"
-      href="http://example.org/abc">
-      "http://example.org/abc"&lt;/a>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
 <div id="ex9-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -1655,7 +1501,6 @@ _:b0 a as:Add ;
     <li><a href="#ex10-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex10-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex10-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex10-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex10-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex10-jsonld" style="display: block;">
@@ -1714,23 +1559,6 @@ _:b0 a as:Add ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex10-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-add">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  added
-  &lt;span class="p-item h-entry">
-    &lt;a class="u-url"  href="http://example.org/abc">
-      "http://example.org/abc"&lt;/a>
-  &lt;/span>
-  to
-  &lt;span class="p-as-target h-entry">
-    "&lt;span class="p-name">My Cat Pictures&lt;/span>"
-  &lt;/span>
-&lt;/div></pre>
-  </div>
 <div id="ex10-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -1780,7 +1608,6 @@ _:b0 a as:Add ;
     <li><a href="#ex11-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex11-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex11-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex11-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex11-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex11-jsonld" style="display: block;">
@@ -1838,22 +1665,6 @@ _:b0 a as:Add ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex11-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-arrive">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;;
-  arrived at
-  &lt;span class="p-as-target h-geo">
-    &lt;span class="p-name">Work&lt;/span>
-  &lt;/span>
-  from
-  &lt;span class="p-as-origin h-geo">
-    &lt;span class="p-name">Home&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
 <div id="ex11-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -1908,7 +1719,6 @@ _:b0 a as:Arrive ;
     <li><a href="#ex12-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex12-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex12-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex12-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex12-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex12-jsonld" style="display: block;">
@@ -1957,21 +1767,6 @@ _:b0 a as:Arrive ;
     "&lt;span property="displayName">A Simple Note&lt;/span>"
     with content
     "&lt;span property="content">This is a simple note&lt;/span>"
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex12-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-create">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  created
-  &lt;span class="p-item h-entry">
-    a note titled
-    "&lt;span class="p-name">A Simple Note&lt;/span>"
-    with content
-    "&lt;span class="e-content">This is a simple note&lt;/span>""
   &lt;/span>
 &lt;/div></pre>
   </div>
@@ -2025,7 +1820,6 @@ _:b0 a as:Create ;
     <li><a href="#ex13-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex13-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex13-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex13-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex13-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex13-jsonld" style="display: block;">
@@ -2066,21 +1860,6 @@ _:b0 a as:Create ;
     href="http://example.org/notes/1">
     http://example.org/notes/1
   &lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex13-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-delete">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  deleted
-  &lt;span class="p-item h-entry">
-    &lt;a class="u-url"
-      href="http://example.org/notes/1">
-      http://example.org/notes/1
-    &lt;/a>
-  &lt;/span>
 &lt;/div></pre>
   </div>
 <div id="ex13-turtle" style="display: none;">
@@ -2126,7 +1905,7 @@ _:b0 a as:Delete ;
     <li><a href="#ex14-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex14-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex14-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex14-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex14-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex14-jsonld" style="display: block;">
@@ -2164,19 +1943,6 @@ _:b0 a as:Delete ;
   &lt;/span>
   favorited
   &lt;a property="object"
-    href="http://example.org/notes/1">
-    http://example.org/notes/1
-  &lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex14-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-favorite">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  favorited
-  &lt;a class="u-favorite-of"
     href="http://example.org/notes/1">
     http://example.org/notes/1
   &lt;/a>
@@ -2228,7 +1994,7 @@ _:b0 a as:Favorite ;
     <li><a href="#ex15-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex15-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex15-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex15-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex15-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex15-jsonld" style="display: block;">
@@ -2270,18 +2036,6 @@ _:b0 a as:Favorite ;
   followed
   &lt;span property="object" typeof="Person">
     &lt;span itemprop="displayName">John&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex15-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-follow">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  followed
-  &lt;span class="p-item h-card">
-    &lt;span class="p-name">John&lt;/span>
   &lt;/span>
 &lt;/div></pre>
   </div>
@@ -2333,7 +2087,7 @@ _:b0 a as:Follow ;
     <li><a href="#ex16-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex16-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex16-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex16-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex16-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex16-jsonld" style="display: block;">
@@ -2373,18 +2127,6 @@ _:b0 a as:Follow ;
   &lt;a property="object"
     href="http://example.org/notes/1">
       http://example.org/notes/1
-  &lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex16-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-ignore">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  is ignoring
-  &lt;a class="p-item" href="http://example.org/notes/1">
-    http://example.org/notes/1
   &lt;/a>
 &lt;/div></pre>
   </div>
@@ -2430,7 +2172,7 @@ _:b0 a as:Ignore ;
     <li><a href="#ex17-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex17-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex17-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex17-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex17-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex17-jsonld" style="display: block;">
@@ -2472,18 +2214,6 @@ _:b0 a as:Ignore ;
   joined
   &lt;span property="object" typeof="Group">
     &lt;span property="displayName">A Simple Group&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex17-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  joined
-  &lt;span class="p-item h-as-group">
-    &lt;span class="p-name">A Simple Group&lt;/span>
   &lt;/span>
 &lt;/div></pre>
   </div>
@@ -2532,7 +2262,7 @@ _:b0 a as:Join ;
     <li><a href="#ex18-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex18-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex18-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex18-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex18-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex18-jsonld" style="display: block;">
@@ -2577,18 +2307,6 @@ _:b0 a as:Join ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex18-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-leave">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  left
-  &lt;span class="p-item h-geo">
-    &lt;span class="p-name">Work&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
 <div id="ex18-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -2610,7 +2328,7 @@ _:b0 a as:Leave ;
     <li><a href="#ex19-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex19-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex19-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex19-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex19-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex19-jsonld" style="display: block;">
@@ -2652,18 +2370,6 @@ _:b0 a as:Leave ;
   left
   &lt;span property="object" typeof="Group">
     &lt;span property="displayName">A Simple Group&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex19-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-leave">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  left
-  &lt;span class="p-item h-as-group">
-    &lt;span class="p-name">A Simple Group&lt;/span>
   &lt;/span>
 &lt;/div></pre>
   </div>
@@ -2712,7 +2418,7 @@ _:b0 a as:Leave ;
     <li><a href="#ex20-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex20-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex20-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex20-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex20-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex20-jsonld" style="display: block;">
@@ -2750,19 +2456,6 @@ _:b0 a as:Leave ;
   &lt;/span>
   liked
   &lt;a property="object"
-    href="http://example.org/notes/1">
-    http://example.org/notes/1
-  &lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex20-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-like">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  liked
-  &lt;a class="u-like-of"
     href="http://example.org/notes/1">
     http://example.org/notes/1
   &lt;/a>
@@ -2812,7 +2505,7 @@ _:b0 a as:Like ;
     <li><a href="#ex21-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex21-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex21-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex21-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex21-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex21-jsonld" style="display: block;">
@@ -2862,18 +2555,6 @@ _:b0 a as:Like ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex21-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-offer">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  is offering
-  &lt;span class="p-item h-entry">
-    &lt;span class="p-name">50% Off!&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
 <div id="ex21-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -2920,7 +2601,7 @@ _:b0 a as:Offer ;
     <li><a href="#ex23-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex23-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex23-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex23-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex23-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex23-jsonld" style="display: block;">
@@ -2979,22 +2660,6 @@ _:b0 a as:Offer ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex23-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-give">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  gave
-  &lt;span class="p-item h-entry">
-    &lt;span class="p-name">A Present&lt;/span>
-  &lt;/span>
-  to
-  &lt;span class="p-as-target h-card">
-    &lt;span class="p-name">John&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
 <div id="ex23-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -3045,7 +2710,7 @@ _:b0 a as:Give ;
     <li><a href="#ex24-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex24-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex24-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex24-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex24-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex24-jsonld" style="display: block;">
@@ -3112,26 +2777,6 @@ _:b0 a as:Give ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex24-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-invite">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  invited
-  &lt;span class="p-as-target h-card">
-    &lt;span class="p-name">John&lt;/span>
-  &lt;/span>
-  and
-  &lt;span class="p-as-target h-card">
-    &lt;span class="p-name">Lisa&lt;/span>
-  &lt;/span>
-  to
-  &lt;span class="p-item h-event">
-    &lt;span class="p-name">A Party&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
 <div id="ex24-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -3187,7 +2832,7 @@ _:b0 a as:Invite ;
     <li><a href="#ex25-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex25-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex25-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex25-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex25-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex25-jsonld" style="display: block;">
@@ -3236,21 +2881,6 @@ _:b0 a as:Invite ;
     "&lt;span property="displayName">A Simple Note&lt;/span>"
     with content
     "&lt;span property="content">This is a simple note&lt;/span>"
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex25-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-post">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  published
-  &lt;span class="p-item h-entry">
-    a note titled
-    "&lt;span class="p-name">A Simple Note&lt;/span>"
-    with content
-    "&lt;span class="e-content">This is a simple note&lt;/span>""
   &lt;/span>
 &lt;/div></pre>
   </div>
@@ -3305,7 +2935,7 @@ _:b0 a as:Post ;
     <li><a href="#ex26-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex26-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex26-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex26-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex26-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex26-jsonld" style="display: block;">
@@ -3373,25 +3003,6 @@ _:b0 a as:Post ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex26-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-reject">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  rejected
-  &lt;span class="p-item h-as-invite">
-    &lt;span class="p-author h-card">
-      &lt;link class="u-url"
-        href="acct:john@example.org">John's&lt;/link>
-    &lt;/span>
-    invitation to
-    &lt;span class="p-item h-event">
-      &lt;span class="p-name">A Party!&lt;/span>
-    &lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
   <div id="ex26-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -3442,7 +3053,7 @@ _:b0 a as:Reject ;
     <li><a href="#ex27-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex27-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex27-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex27-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex27-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex27-jsonld" style="display: block;">
@@ -3510,25 +3121,6 @@ _:b0 a as:Reject ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex27-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-tentativereject">
-  &lt;span class="p-author h-card" >
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;span>
-  tentatively rejected
-  &lt;span class="p-item h-as-invite">
-    &lt;span class="p-author h-card">
-      &lt;link class="u-url"
-        href="acct:john@example.org">John's&lt;/link>
-    &lt;/span>
-    invitation to
-    &lt;span class="p-item h-event">
-      &lt;span class="p-name">A Party!&lt;/span>
-    &lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
   <div id="ex27-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -3578,7 +3170,7 @@ _:b0 a as:TentativeReject ;
     <li><a href="#ex28-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex28-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex28-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex28-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex28-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex28-jsonld" style="display: block;">
@@ -3642,23 +3234,6 @@ _:b0 a as:TentativeReject ;
   &lt;span>
 &lt;/div></pre>
   </div>
-  <div id="ex28-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-remove">
-  &lt;span class="p-author h-card" >
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;span>
-  removed
-  &lt;a class="u-item"
-    href="http://example.org/notes/1">
-    http://example.org/notes/1
-  &lt;/a>
-  from
-  &lt;span class="p-as-origin h-entry">
-    &lt;span>Notes Folder&lt;span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
   <div id="ex28-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -3682,7 +3257,7 @@ _:b0 a as:Remove ;
     <li><a href="#ex29-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex29-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex29-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex29-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex29-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex29-jsonld" style="display: block;">
@@ -3752,24 +3327,6 @@ _:b0 a as:Remove ;
   &lt;span>
 &lt;/div></pre>
   </div>
-  <div id="ex29-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-remove">
-  &lt;span class="p-author h-card" >
-    &lt;span class="p-name">The Moderator&lt;/span>
-  &lt;span>
-  removed
-  &lt;span class="p-item h-card" >
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;span>
-  from
-  &lt;span class="p-as-origin h-as-group">
-    &lt;span class="p-name">
-      A Simple Group
-    &lt;/span>
-  &lt;span>
-&lt;/div></pre>
-  </div>
   <div id="ex29-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -3823,7 +3380,7 @@ _:b0 a as:Remove ;
     <li><a href="#ex160-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex160-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex160-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex160-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex160-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex160-jsonld" style="display: block;">
@@ -3871,24 +3428,6 @@ _:b0 a as:Remove ;
   &lt;/span>"
 &lt;/div></pre>
   </div>
-  <div id="ex160-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-review">
-  &lt;span class="p-author h-card" >
-    &lt;link class="u-url" href="acct:sally@example.org">
-      The Moderator
-    &lt;/link>
-  &lt;span>
-  reviewed
-  &lt;a class="u-item"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>,
-  "&lt;span>
-    I liked this post
-  &lt;/span>"
-&lt;/div></pre>
-  </div>
   <div id="ex160-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -3932,7 +3471,7 @@ _:b0 a as:Review ;
     <li><a href="#ex30-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex30-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex30-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex30-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex30-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex30-jsonld" style="display: block;">
@@ -3996,23 +3535,6 @@ _:b0 a as:Review ;
   &lt;span>
 &lt;/div></pre>
   </div>
-  <div id="ex30-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-save">
-  &tl;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;span>
-  &lt;/span>
-  saved
-  &lt;a class="u-item"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  to
-  &lt;span class="p-as-target h-as-collection">
-    &lt;span class="p-name">Sally's Reading List&lt;span>
-  &lt;span>
-&lt;/div></pre>
-  </div>
   <div id="ex30-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -4061,7 +3583,7 @@ _:b0 a as:Save ;
     <li><a href="#ex31-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex31-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex31-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex31-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex31-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex31-jsonld" style="display: block;">
@@ -4113,21 +3635,6 @@ _:b0 a as:Save ;
   &lt;/link>
 &lt;/div></pre>
   </div>
-  <div id="ex31-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;link class="p-author"
-    href="acct:sally@example.org">Sally&lt;link>
-  shared
-  &lt;a class="u-share-of"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link class="u-as-target"
-    href="acct:sally@example.org">John&lt;link>
-&lt;/div></pre>
-  </div>
   <div id="ex31-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -4171,7 +3678,7 @@ _:b0 a as:Share ;
     <li><a href="#ex32-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex32-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex32-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex32-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex32-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex32-jsonld" style="display: block;">
@@ -4238,27 +3745,6 @@ _:b0 a as:Share ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex32-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-undo">
-  &lt;link class="u-author"href="acct:sally@example.org">
-    Sally
-  &lt;/link>
-  stopped
-  &lt;span class="h-as-share">
-    sharing
-    &lt;a class="u-item"
-      href="http://example.org/posts/1">
-      http://example.org/posts/1
-    &lt;/a>
-    with
-    &lt;link class="u-as-target"
-      href="acct:john@example.org">
-      John
-    &lt;/link>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
   <div id="ex32-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -4304,7 +3790,7 @@ _:b0 a as:Undo ;
     <li><a href="#ex33-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex33-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex33-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex33-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex33-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex33-jsonld" style="display: block;">
@@ -4342,19 +3828,6 @@ _:b0 a as:Undo ;
   &lt;/span>
   updated
   &lt;a property="object"
-    href="http://example.org/notes/1">
-    http://example.org/notes/1
-  &lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex33-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-update">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  updated
-  &lt;a class="u-item"
     href="http://example.org/notes/1">
     http://example.org/notes/1
   &lt;/a>
@@ -4404,7 +3877,7 @@ _:b0 a as:Update ;
     <li><a href="#ex160-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex160-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex160-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex160-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex160-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex160-jsonld" style="display: block;">
@@ -4448,20 +3921,6 @@ _:b0 a as:Update ;
   experienced
   &lt;span property="object" typeof="Article">
     "&lt;span property="displayName">
-      An article about Activity Streams
-    &lt;span>"
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex160-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-experience">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  experienced
-  &lt;span class="p-item h-entry">
-    "&lt;span class="p-name">
       An article about Activity Streams
     &lt;span>"
   &lt;/span>
@@ -4512,7 +3971,7 @@ _:b0 a as:Experience ;
     <li><a href="#ex161-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex161-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex161-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex161-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex161-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex161-jsonld" style="display: block;">
@@ -4556,20 +4015,6 @@ _:b0 a as:Experience ;
   viewed
   &lt;span property="object" typeof="Article">
     "&lt;span property="displayName">
-      An article about Activity Streams
-    &lt;span>"
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex161-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-view">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  viewed
-  &lt;span class="p-item h-entry">
-    "&lt;span class="p-name">
       An article about Activity Streams
     &lt;span>"
   &lt;/span>
@@ -4622,7 +4067,7 @@ _:b0 a as:View ;
     <li><a href="#ex163-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex163-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex163-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex163-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex163-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex163-jsonld" style="display: block;">
@@ -4661,18 +4106,6 @@ _:b0 a as:View ;
   listened to
   &lt;a property="object"
     href="http://example.org/music.mp3">
-    "http://example.org/music.mp3"
-  &lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex163-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-listen">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  listened to
-  &lt;a class="u-item" href="http://example.org/music.mp3">
     "http://example.org/music.mp3"
   &lt;/a>
 &lt;/div></pre>
@@ -4722,7 +4155,7 @@ _:b0 a as:Listen ;
     <li><a href="#ex164-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex164-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex164-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex164-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex164-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex164-jsonld" style="display: block;">
@@ -4761,18 +4194,6 @@ _:b0 a as:Listen ;
   read
   &lt;a property="object"
     href="http://example.org/posts/1">
-    "http://example.org/posts/1"
-  &lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex164-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-read">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  read
-  &lt;a class="u-item" href="http://example.org/posts/1">
     "http://example.org/posts/1"
   &lt;/a>
 &lt;/div></pre>
@@ -4821,7 +4242,7 @@ _:b0 a as:Read ;
     <li><a href="#ex168-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex168-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex168-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex168-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex168-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex168-jsonld" style="display: block;">
@@ -4890,26 +4311,6 @@ _:b0 a as:Read ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex168-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-move">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  moved
-  &lt;a class="u-item" href="http://example.org/posts/1">
-    "http://example.org/posts/1"
-  &lt;/a>
-  from
-  &lt;span class="p-as-origin h-entry">
-    &lt;span class="p-name">List A&lt;/span>
-  &lt;/span>
-  to
-  &lt;span class="p-as-target h-entry">
-    &lt;span class="p-name">List B&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
 <div id="ex168-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -4963,7 +4364,7 @@ _:b0 a as:Move ;
     <li><a href="#ex169-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex169-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex169-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex169-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex169-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex169-jsonld" style="display: block;">
@@ -5018,22 +4419,6 @@ _:b0 a as:Move ;
   from
   &lt;span property="origin" typeof="Place">
     &lt;span property="displayName">Work&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex169-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-travel">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  is traveling to
-  &lt;span class="p-as-target h-geo">
-    &lt;span class="p-name">Home&lt;/span>
-  &lt;/span>
-  from
-  &lt;span class="p-as-origin h-geo">
-    &lt;span class="p-name">Work&lt;/span>
   &lt;/span>
 &lt;/div></pre>
   </div>
@@ -5093,7 +4478,7 @@ _:b0 a as:Travel ;
     <li><a href="#ex170-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex170-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex170-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex170-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex170-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex170-jsonld" style="display: block;">
@@ -5154,19 +4539,6 @@ _:b0 a as:Travel ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex170-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-announce">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  announced
-  &lt;span class="p-item h-as-arrive">
-    her arrival at
-    &lt;span class="p-location h-geo">work&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
 <div id="ex170-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -5217,7 +4589,7 @@ _:b0 a as:Announce ;
     <li><a href="#ex173-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex173-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex173-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex173-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex173-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex173-jsonld" style="display: block;">
@@ -5247,16 +4619,6 @@ _:b0 a as:Announce ;
     href="acct:sally@example.org">Sally&lt;/link>
   blocked
   &lt;link property="object"
-    href="acct:joe@example.org">Joe&lt;/link>
-&lt;/div></pre>
-  </div>
-  <div id="ex173-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-block">
-  &lt;link class="u-actor"
-    href="acct:sally@example.org">Sally&lt;/link>
-  blocked
-  &lt;link class="u-item"
     href="acct:joe@example.org">Joe&lt;/link>
 &lt;/div></pre>
   </div>
@@ -5303,7 +4665,7 @@ _:b0 a as:Block ;
     <li><a href="#ex174-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex174-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex174-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex174-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex174-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex174-jsonld" style="display: block;">
@@ -5343,17 +4705,6 @@ _:b0 a as:Block ;
     "&lt;span property="content">
       An inappropriate note
     &lt;/span>"
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex174-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-flag">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">Sally&lt;/link>
-  flagged
-  &lt;span class="p-item h-entry">
-    "&lt;span class="e-content">An inappropriate note&lt;/span>"
   &lt;/span>
 &lt;/div></pre>
   </div>
@@ -5401,7 +4752,7 @@ _:b0 a as:Flag ;
     <li><a href="#ex175-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex175-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex175-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex175-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex175-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex175-jsonld" style="display: block;">
@@ -5432,17 +4783,6 @@ _:b0 a as:Flag ;
     href="acct:sally@example.org">Sally&lt;/link>
   dislikes
   &lt;a property="object" href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex175-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-dislike">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">Sally&lt;/link>
-  dislikes
-  &lt;a class="u-dislike-of" href="http://example.org/posts/1">
     http://example.org/posts/1
   &lt;/a>
 &lt;/div></pre>
@@ -5486,7 +4826,7 @@ _:b0 a as:Dislike ;
     <li><a href="#ex176-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex176-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex176-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex176-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex176-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex176-jsonld" style="display: block;">
@@ -5538,17 +4878,6 @@ _:b0 a as:Dislike ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex176-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-confirm">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">Sally&lt;/link>
-  confirmed her reservation for
-  &lt;a class="u-item" href="http://example.org/posts/1">
-    http://example.org/events/1
-  &lt;/a>
-&lt;/div></pre>
-  </div>
 <div id="ex176-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -5593,7 +4922,7 @@ _:b0 a as:Confirm ;
     <li><a href="#ex178-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex178-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex178-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex178-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex178-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex178-jsonld" style="display: block;">
@@ -5636,20 +4965,6 @@ _:b0 a as:Confirm ;
   &lt;/span>
   to
   &lt;link property="target"
-    href="acct:joe@example.org">Joe&lt;/link>
-&lt;/div></pre>
-  </div>
-  <div id="ex178-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-assign">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">Sally&lt;/link>
-  assigned the role of
-  &lt;span class="p-item h-entry">
-    &lt;span class="p-name">Moderator&lt;/span>
-  &lt;/span>
-  to
-  &lt;link class="u-target"
     href="acct:joe@example.org">Joe&lt;/link>
 &lt;/div></pre>
   </div>
@@ -5697,7 +5012,7 @@ _:b0 a as:Assign ;
     <li><a href="#ex179-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex179-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex179-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex179-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex179-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex179-jsonld" style="display: block;">
@@ -5729,18 +5044,6 @@ _:b0 a as:Assign ;
     href="acct:sally@example.org">Sally&lt;/link>
   has completed
   &lt;a property="object"
-    href="http://example.org/tasks/1">
-      http://example.org/tasks/1
-  &lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex179-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-complete">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">Sally&lt;/link>
-  has completed
-  &lt;a class="u-item"
     href="http://example.org/tasks/1">
       http://example.org/tasks/1
   &lt;/a>
@@ -5817,7 +5120,7 @@ _:b0 a as:Complete ;
     <li><a href="#ex34-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex34-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex34-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex34-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex34-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex34-jsonld" style="display: block;">
@@ -5840,10 +5143,6 @@ _:b0 a as:Complete ;
   typeof="Application">
   &lt;span property="displayName">My Software Application&lt;/span>
 &lt;/div></pre>
-  </div>
-  <div id="ex34-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-application p-name">My Software Application&lt;/div></pre>
   </div>
 <div id="ex34-turtle" style="display: none;">
 <pre class="example highlight turtle">
@@ -5881,7 +5180,7 @@ _:b0 a as:Application ;
     <li><a href="#ex37-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex37-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex37-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex37-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex37-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex37-jsonld" style="display: block;">
@@ -5904,10 +5203,6 @@ _:b0 a as:Application ;
   typeof="Group">
   &lt;span property="displayName">A Simple Group&lt;/span>
 &lt;/div></pre>
-  </div>
-  <div id="ex37-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-group p-name">A Simple Group&lt;/div></pre>
   </div>
 <div id="ex37-turtle" style="display: none;">
 <pre class="example highlight turtle">
@@ -5945,7 +5240,7 @@ _:b0 a as:Group ;
     <li><a href="#ex39-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex39-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex39-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex39-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex39-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex39-jsonld" style="display: block;">
@@ -5968,10 +5263,6 @@ _:b0 a as:Group ;
   typeof="Person">
   &lt;span property="displayName">Sally Smith&lt;/span>
 &lt;/div></pre>
-  </div>
-  <div id="ex39-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-card p-name">Sally Smith&lt;/div></pre>
   </div>
 <div id="ex39-turtle" style="display: none;">
 <pre class="example highlight turtle">
@@ -6009,7 +5300,7 @@ _:b0 a as:Person ;
     <li><a href="#ex40-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex40-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex40-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex40-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex40-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex40-jsonld" style="display: block;">
@@ -6032,10 +5323,6 @@ _:b0 a as:Person ;
   typeof="Process">
   &lt;span property="displayName">A Long Running Process&lt;/span>
 &lt;/div></pre>
-  </div>
-  <div id="ex40-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-process p-name">A Long Running Process&lt;/div></pre>
   </div>
 <div id="ex40-turtle" style="display: none;">
 <pre class="example highlight turtle">
@@ -6074,7 +5361,7 @@ _:b0 a as:Process ;
     <li><a href="#ex42-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex42-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex42-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex42-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex42-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex42-jsonld" style="display: block;">
@@ -6097,10 +5384,6 @@ _:b0 a as:Process ;
   typeof="Service">
   &lt;span property="displayName">Acme Web Service&lt;/span>
 &lt;/div></pre>
-  </div>
-  <div id="ex42-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-service p-name">Acme Web Service&lt;/div></pre>
   </div>
 <div id="ex42-turtle" style="display: none;">
 <pre class="example highlight turtle">
@@ -6184,7 +5467,7 @@ _:b0 a as:Service ;
     <li><a href="#ex22-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex22-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex22-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex22-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex22-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex22-jsonld" style="display: block;">
@@ -6233,18 +5516,6 @@ _:b0 a as:Service ;
   &lt;/span>
   &lt;span property="b" typeof="Person">
     &lt;span property="displayName">John&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex22-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-connection">
-  &lt;span class="h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  knows
-  &lt;span class="h-card">
-    &lt;span class="p-name">John&lt;/span>
   &lt;/span>
 &lt;/div></pre>
   </div>
@@ -6298,7 +5569,7 @@ _:b0 a as:Connection ;
     <li><a href="#ex35-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex35-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex35-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex35-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex35-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex35-jsonld" style="display: block;">
@@ -6334,15 +5605,6 @@ _:b0 a as:Connection ;
   &lt;/div>
   &lt;meta property="height" content="100" />
   &lt;meta property="width" content="100" />
-&lt;/div></pre>
-  </div>
-  <div id="ex35-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry" style="width:100px; height:100px">
-  &lt;div property="p-name">Some generic content&lt;/div>
-  &lt;div property="e-content">
-    &lt;p>This can be any kind of content&lt;/p>
-  &lt;/div>
 &lt;/div></pre>
   </div>
 <div id="ex35-turtle" style="display: none;">
@@ -6398,7 +5660,7 @@ _:b0 a as:Content ;
     <li><a href="#ex43-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex43-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex43-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex43-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex43-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex43-jsonld" style="display: block;">
@@ -6430,19 +5692,6 @@ _:b0 a as:Content ;
   &lt;div>By &lt;a property="attributedTo"
     href="acct:sally@example.org">Sally&lt;/a>&lt;/div>
   &lt;section property="content"
-    &lt;div>... a long blog post&lt;/div>
-  &lt;/section>
-&lt;/div></pre>
-  </div>
-  <div id="ex43-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;h2 class="p-name">A Blog Post&lt;/h2>
-  &lt;div class="p-author h-card">
-    By &lt;a class="p-name u-url"
-    href="acct:sally@example.org">Sally&lt;/a>
-  &lt;/div>
-  &lt;section class="e-content"
     &lt;div>... a long blog post&lt;/div>
   &lt;/section>
 &lt;/div></pre>
@@ -6484,7 +5733,7 @@ _:b0 a as:Article ;
     <li><a href="#ex44-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex44-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex44-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex44-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex44-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex44-jsonld" style="display: block;">
@@ -6564,28 +5813,6 @@ _:b0 a as:Article ;
   &lt;/figure>
 &lt;/div></pre>
   </div>
-  <div id="ex44-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-album">
-  &lt;h2 class="p-name">A Photo Album&lt;/h2>
-  &lt;figure class="p-as-items h-entry">
-    &lt;figcaption class="p-name">
-      My Dog
-    &lt;/figcaption>
-    &lt;img class="u-photo"
-      src="http://example.org/dog.jpeg"
-      type="image/jpeg" />
-  &lt;/figure>
-  &lt;figure class="p-as-items h-entry">
-    &lt;figcaption class="p-name">
-      My Cat
-    &lt;/figcaption>
-    &lt;img class="u-photo"
-      src="http://example.org/cat.jpeg"
-      type="image/jpeg" />
-  &lt;/figure>
-&lt;/div></pre>
-  </div>
 <div id="ex44-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -6620,7 +5847,7 @@ _:b0 a as:Album ;
     <li><a href="#ex45-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex45-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex45-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex45-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex45-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex45-jsonld" style="display: block;">
@@ -6696,26 +5923,6 @@ _:b0 a as:Album ;
   &lt;/ol&gt;
 &lt;/div></pre>
   </div>
-  <div id="ex45-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-album">
-  &lt;h2 class="p-name">A Music Playlist&lt;/h2>
-  &lt;ol class="p-as-items"&gt;
-    &lt;li class="h-entry">
-      &lt;span class="p-name">Song 1&lt;/span> -
-      &lt;a class="u-url"
-        href="http://example.org/song1.mp3"
-        type="audio/mp3">Listen&lt;/a>
-    &lt;/li>
-    &lt;li class="h-entry">
-      &lt;span class="p-name">Song 2&lt;/span> -
-      &lt;a class="u-url"
-        href="http://example.org/song2.mp3"
-        type="audio/mp3">Listen&lt;/a>
-    &lt;/li>
-  &lt;/ol&gt;
-&lt;/div></pre>
-  </div>
 <div id="ex45-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -6778,7 +5985,7 @@ _:b0 a as:Album ;
     <li><a href="#ex46-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex46-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex46-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex46-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex46-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex46-jsonld" style="display: block;">
@@ -6820,20 +6027,6 @@ _:b0 a as:Album ;
       &lt;span property="displayName">4Q Sales Forecast&lt;/span> -
       &lt;a property="url"
         href="http://example.org/4q-sales-forecast.pdf">Open&lt;/a>
-    &lt;/li>
-  &lt;/ul&gt;
-&lt;/div></pre>
-  </div>
-  <div id="ex46-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-folder">
-  &lt;h2 class="p-name">Some Documents&lt;/h2>
-  &lt;ul class="p-as-items"&gt;
-    &lt;li class="h-entry">
-      &lt;a class="u-url p-name"
-        href="http://example.org/4q-sales-forecast.pdf">
-        4Q Sales Forecast
-        &lt;/a>
     &lt;/li>
   &lt;/ul&gt;
 &lt;/div></pre>
@@ -6883,7 +6076,7 @@ _:b0 a as:Folder ;
     <li><a href="#ex47-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex47-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex47-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex47-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex47-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex47-jsonld" style="display: block;">
@@ -6980,26 +6173,6 @@ _:b0 a as:Folder ;
   &lt;/figure>
 &lt;/div></pre>
   </div>
-  <div id="ex47-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-story">
-  &lt;h2 class="p-name">My Vacation&lt;/h2>
-  &lt;figure class="p-as-items h-entry">
-    &lt;figcaption class="p-name"&gt;
-      Visiting the Vatican
-    &lt;/figcaption&gt;
-    &lt;img class="u-photo"
-      href="http://example.org/photo5.jpeg" />
-  &lt;/figure>
-  &lt;figure class="p-as-items h-entry">
-    &lt;figcaption class="p-name"&gt;
-      Visiting the Eiffel Tower
-    &lt;/figcaption&gt;
-    &lt;img class="u-photo"
-      href="http://example.org/photo6.jpeg" />
-  &lt;/figure>
-&lt;/div></pre>
-  </div>
 <div id="ex47-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -7062,7 +6235,7 @@ _:b0 a as:Story ;
     <li><a href="#ex48-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex48-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex48-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex48-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex48-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex48-jsonld" style="display: block;">
@@ -7089,15 +6262,6 @@ _:b0 a as:Story ;
 &lt;span property="displayName">4Q Sales Forecast&lt;/span> -
   &lt;a property="url"
     href="http://example.org/4q-sales-forecast.pdf">Open&lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex48-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-document">
-&lt;span class="p-name">4Q Sales Forecast&lt;/span> -
-  &lt;a class="u-url"
-    href="http://example.org/4q-sales-forecast.pdf">Open&lt;/a>
-&lt;/div>
 &lt;/div></pre>
   </div>
 <div id="ex48-turtle" style="display: none;">
@@ -7137,7 +6301,7 @@ _:b0 a as:Document ;
     <li><a href="#ex49-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex49-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex49-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex49-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex49-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex49-jsonld" style="display: block;">
@@ -7171,16 +6335,6 @@ _:b0 a as:Document ;
   &lt;a property="url" typeof="Link"
     href="http://example.org/podcast.mp3"
     type="audio/mp3">Listen&lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex49-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-audio">
-&lt;span class="p-name">A Simple Podcast&lt;/span> -
-  &lt;a class="u-url"
-    href="http://example.org/podcast.mp3"
-    type="audio/mp3">Listen&lt;/a>
-&lt;/div>
 &lt;/div></pre>
   </div>
 <div id="ex49-turtle" style="display: none;">
@@ -7224,7 +6378,7 @@ _:b0 a as:Audio ;
     <li><a href="#ex50-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex50-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex50-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex50-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex50-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex50-jsonld" style="display: block;">
@@ -7272,19 +6426,6 @@ _:b0 a as:Audio ;
 &lt;a property="url" typeof="Link"
     href="http://example.org/image.png"
     type="image/png">PNG&lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex50-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-image">
-&lt;span class="p-name">A Simple Image&lt;/span> -
-  &lt;a class="u-url"
-    href="http://example.org/image.jpeg"
-    type="image/jpeg">JPEG&lt;/a> |
-  &lt;a class="u-url"
-    href="http://example.org/image.png"
-    type="image/png">PNG&lt;/a>
-&lt;/div>
 &lt;/div></pre>
   </div>
 <div id="ex50-turtle" style="display: none;">
@@ -7335,7 +6476,7 @@ _:b0 a as:Image ;
     <li><a href="#ex51-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex51-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex51-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex51-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex51-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex51-jsonld" style="display: block;">
@@ -7364,16 +6505,6 @@ _:b0 a as:Image ;
 &lt;span property="displayName">A Simple Video&lt;/span>
   &lt;meta property="duration" content="PT2H">(2 hours)&lt;meta> -
   &lt;a property="url"
-    href="http://example.org/video.mkv">Watch&lt;a>
-&lt;/div></pre>
-  </div>
-  <div id="ex51-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-video">
-&lt;span class="p-name">A Simple Video&lt;/span>
-  &lt;meta class="p-as-duration" name="duration"
-    content="PT2H">(2 hours)&lt;meta> -
-  &lt;a class="u-url"
     href="http://example.org/video.mkv">Watch&lt;a>
 &lt;/div></pre>
   </div>
@@ -7415,7 +6546,7 @@ _:b0 a as:Video ;
     <li><a href="#ex52-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex52-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex52-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex52-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex52-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex52-jsonld" style="display: block;">
@@ -7442,15 +6573,6 @@ _:b0 a as:Video ;
   typeof="Note">
   &lt;h2 property="displayName">A Short Note&lt;/h2>
   &lt;section property="content">
-    This is a short note
-  &lt;/section>
-&lt;/div></pre>
-  </div>
-  <div id="ex52-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;h2 class="p-name">A Short Note&lt;/h2>
-  &lt;section class="e-content">
     This is a short note
   &lt;/section>
 &lt;/div></pre>
@@ -7492,7 +6614,7 @@ _:b0 a as:Note ;
     <li><a href="#ex53-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex53-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex53-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex53-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex53-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex53-jsonld" style="display: block;">
@@ -7521,13 +6643,6 @@ _:b0 a as:Note ;
     href="http://example.org/page.html">
     &lt;meta property="displayName">A Webpage&lt;/meta>
   &lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex53-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;a class="u-url p-name"
-    href="http://example.org/page.html">A Webpage&lt;/a>
 &lt;/div></pre>
   </div>
 <div id="ex53-turtle" style="display: none;">
@@ -7567,7 +6682,7 @@ _:b0 a as:Page ;
     <li><a href="#ex55-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex55-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex55-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex55-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex55-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex55-jsonld" style="display: block;">
@@ -7619,22 +6734,6 @@ _:b0 a as:Page ;
     &lt;/li&gt;
     &lt;li property="oneOf" typeof="Note"&gt;
       &lt;span property="displayName">Option B&lt;/span&gt;
-    &lt;/li&gt;
-  &lt;ul&gt;
-&lt;/div></pre>
-  </div>
-  <div id="ex55-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-question">
-  &lt;h2 class="p-name">
-    What is the answer?
-  &lt;/h2>
-  &lt;ul class="p-as-one-of"&gt;
-    &lt;li class="h-entry"&gt;
-      &lt;span class-"p-name">Option A&lt;/span&gt;
-    &lt;/li&gt;
-    &lt;li class="h-entry"&gt;
-      &lt;span class-"p-name">Option B&lt;/span&gt;
     &lt;/li&gt;
   &lt;ul&gt;
 &lt;/div></pre>
@@ -7694,7 +6793,7 @@ _:b0 a as:Question ;
     <li><a href="#ex56-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex56-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex56-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex56-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex56-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex56-jsonld" style="display: block;">
@@ -7740,24 +6839,6 @@ _:b0 a as:Question ;
   &lt;/div>
 &lt;/div></pre>
   </div>
-  <div id="ex56-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-event">
-  &lt;h2 class="p-name">A Party&lt;/h2>
-  &lt;div>Starts:
-  &lt;meta class="dt-start" name="startTime"
-    content="2014-12-31T23:00:00-08:00">
-    11:00 PM on Dec 31, 2014
-  &lt;/meta>
-  &lt;/div>
-  &lt;div>Ends:
-  &lt;meta class="dt-end" name="endTime"
-    content="2015-01-01T06:00:00-08:00">
-    06:00 AM on Jan 1, 2015
-  &lt;/meta>
-  &lt;/div>
-&lt;/div></pre>
-  </div>
 <div id="ex56-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -7797,7 +6878,7 @@ _:b0 a as:Event ;
     <li><a href="#ex57-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex57-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex57-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex57-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex57-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex57-jsonld" style="display: block;">
@@ -7821,10 +6902,6 @@ _:b0 a as:Event ;
   &lt;span property="displayName">Work&lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex57-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-geo p-name">Work&lt;/div></pre>
-  </div>
 <div id="ex57-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -7839,7 +6916,7 @@ _:b0 a as:Place ;
     <li><a href="#ex58-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex58-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex58-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex58-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex58-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex58-jsonld" style="display: block;">
@@ -7905,31 +6982,6 @@ _:b0 a as:Place ;
   &lt;/tr>
 &lt;/table></pre>
   </div>
-  <div id="ex58-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;table class="h-geo">
-  &lt;tr>
-    &lt;td>Name&lt;/td>
-    &lt;td class="p-name">Fresno Area&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Latitude&lt;/td>
-    &lt;td class="p-latitude">36.75&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Longitude&lt;/td>
-    &lt;td class="p-longitude">119.7667&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Radius&lt;/td>
-    &lt;td class="p-as-radius">15&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Units&lt;/td>
-    &lt;td class="p-as-units">miles&lt;/td>
-  &lt;/tr>
-&lt;/table></pre>
-  </div>
 <div id="ex58-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -7984,7 +7036,7 @@ _:b0 a as:Place ;
     <li><a href="#ex181-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex181-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex181-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex181-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex181-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex181-jsonld" style="display: block;">
@@ -8013,10 +7065,6 @@ _:b0 a as:Place ;
   &lt;/a>
 &lt;/span></pre>
   </div>
-  <div id="ex181-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;a rel="mention" href="http://example.org/joe">Joe&lt;/a></pre>
-</div>
 <div id="ex181-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -8058,7 +7106,7 @@ _:b0 a as:Mention ;
     <li><a href="#ex184-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex184-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex184-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex184-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex184-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex184-jsonld" style="display: block;">
@@ -8091,13 +7139,6 @@ _:b0 a as:Mention ;
   &lt;section property="attributedTo" typeof="Person">
     &lt;span property="displayName">Sally Smith&lt;/span>
   &lt;/section>
-&lt;/div></pre>
-  </div>
-  <div id="ex184-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-card">
-  &lt;h2 class="p-name">Sally's Profile&lt;/h2>
-  &lt;section class="p-author">Sally Smith&lt;/section>
 &lt;/div></pre>
   </div>
 <div id="ex184-turtle" style="display: none;">
@@ -8422,7 +7463,7 @@ _:b0 a as:Profile ;
     <li><a href="#ex59-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex59-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex59-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex59-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex59-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex59-jsonld" style="display: block;">
@@ -8459,18 +7500,6 @@ _:b0 a as:Profile ;
   &lt;/a>
 &lt;/div></pre>
   </div>
-  <div id="ex59-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;link class="u-author
-    href="acct:sally@example.org">Sally&lt;/link>
-  shared
-  &lt;a class="u-item"
-    href="http://example.org/foo">
-    http://example.org/foo
-  &lt;/a>
-&lt;/div></pre>
-  </div>
 <div id="ex59-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -8487,7 +7516,7 @@ _:b0 a as:Share ;
     <li><a href="#ex60-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex60-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex60-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex60-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex60-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex60-jsonld" style="display: block;">
@@ -8533,19 +7562,6 @@ _:b0 a as:Share ;
   &lt;/a>
 &lt;/div></pre>
   </div>
-  <div id="ex60-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  shared
-  &lt;a class="u-item"
-    href="http://example.org/foo">
-    http://example.org/foo
-  &lt;/a>
-&lt;/div></pre>
-  </div>
 <div id="ex60-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -8564,7 +7580,7 @@ _:b0 a as:Share ;
     <li><a href="#ex61-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex61-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex61-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex61-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex61-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex61-jsonld" style="display: block;">
@@ -8614,23 +7630,6 @@ _:b0 a as:Share ;
   &lt;/span>
   shared
   &lt;a property="object"
-    href="http://example.org/foo">
-    http://example.org/foo
-  &lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex61-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;link class="u-author"
-    href="acct:joe@example.org">Joe&lt;/link>
-  and
-  &lt;span class="p-author h-card">
-    &lt;link class="u-url p-name"
-      href="acct:sally@example.org">Sally&lt;/link>
-  &lt;/span>
-  shared
-  &lt;a class="u-item"
     href="http://example.org/foo">
     http://example.org/foo
   &lt;/a>
@@ -8688,7 +7687,7 @@ _:b0 a as:Share ;
     <li><a href="#ex64-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex64-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex64-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex64-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex64-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex64-jsonld" style="display: block;">
@@ -8744,24 +7743,6 @@ _:b0 a as:Share ;
 &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex64-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="p-name">A Simple Note&lt;/span>
-  Attachments:
-  &lt;ul class="p-as-attachment">
-  &lt;li class="h-entry">
-    &lt;figure>
-      &lt;figcaption class="p-name">
-        A Simple Image
-      &lt;/figcaption>
-      &lt;img class="u-url"
-        href="http://example.org/cat.jpeg" />
-    &lt;/figure>
-  &lt;/li>
-&lt;/ul>
-&lt;/div></pre>
-  </div>
 <div id="ex64-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -8806,7 +7787,7 @@ _:b0 a as:Note ;
     <li><a href="#ex65-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex65-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex65-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex65-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex65-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex65-jsonld" style="display: block;">
@@ -8848,17 +7829,6 @@ _:b0 a as:Note ;
   &lt;/div>
 &lt;/div></pre>
   </div>
-  <div id="ex65-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="p-name">A Simple Image&lt;/span>
-  &lt;img class="u-url" src="http://example.org/cat.jpeg"/>
-  &lt;div class="p-author h-card">
-    Attributed To:
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/div>
-&lt;/div></pre>
-  </div>
 <div id="ex65-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -8878,7 +7848,7 @@ _:b0 a as:Image ;
     <li><a href="#ex66-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex66-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex66-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex66-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex66-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex66-jsonld" style="display: block;">
@@ -8923,20 +7893,6 @@ _:b0 a as:Image ;
   &lt;/span> and
   &lt;link property="attributedTo"
     href="acct:joe@example.org">Joe&lt;link>
-&lt;/div></pre>
-  </div>
-  <div id="ex66-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="p-name">A Simple Image&lt;/span>
-  &lt;img class="u-url" src="http://example.org/cat.jpeg"/>
-  Attributed To:
-  &lt;span class="p-author h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  and
-  &lt;link class="u-author"
-    href="acct:joe@example.org">Joe&lt;/link>
 &lt;/div></pre>
   </div>
 <div id="ex66-turtle" style="display: none;">
@@ -8986,7 +7942,7 @@ _:b0 a as:Image ;
     <li><a href="#ex68-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex68-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex68-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex68-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex68-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex68-jsonld" style="display: block;">
@@ -9047,27 +8003,6 @@ _:b0 a as:Image ;
   &lt;/link>)
 &lt;/div></pre>
   </div>
-  <div id="ex68-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">Sally&lt;link>
-  shared
-  &lt;a class="u-share-of"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link class="u-as-target"
-    href="acct:sally@example.org">
-      John
-  &lt;link>
-  (bcc: &lt;link class="u-as-bcc"
-    href="acct:joe@example.org">
-    John
-  &lt;/link>)
-&lt;/div></pre>
-  </div>
   <div id="ex68-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -9110,7 +8045,7 @@ _:b0 a as:Share ;
     <li><a href="#ex69-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex69-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex69-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex69-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex69-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex69-jsonld" style="display: block;">
@@ -9171,29 +8106,6 @@ _:b0 a as:Share ;
   &lt;/link>)
 &lt;/div></pre>
   </div>
-  <div id="ex69-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">
-      Sally
-  &lt;link>
-  shared
-  &lt;a class="u-share-of"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link class="u-as-target"
-    href="acct:sally@example.org">
-      John
-  &lt;link>
-  (bto: &lt;link class="u-as-bto"
-    href="acct:joe@example.org">
-    John
-  &lt;/link>)
-&lt;/div></pre>
-  </div>
   <div id="ex69-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -9236,7 +8148,7 @@ _:b0 a as:Share ;
     <li><a href="#ex70-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex70-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex70-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex70-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex70-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex70-jsonld" style="display: block;">
@@ -9297,29 +8209,6 @@ _:b0 a as:Share ;
   &lt;/link>)
 &lt;/div></pre>
   </div>
-  <div id="ex70-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">
-      Sally
-  &lt;link>
-  shared
-  &lt;a class="u-share-of"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link class="u-as-target"
-    href="acct:sally@example.org">
-      John
-  &lt;link>
-  (cc: &lt;link class="u-as-cc"
-    href="acct:joe@example.org">
-    John
-  &lt;/link>)
-&lt;/div></pre>
-  </div>
   <div id="ex70-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -9362,7 +8251,7 @@ _:b0 a as:Share ;
     <li><a href="#ex171-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex171-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex171-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex171-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex171-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex171-jsonld" style="display: block;">
@@ -9465,44 +8354,6 @@ _:b0 a as:Share ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex171-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;ul class="p-as-items">
-    &lt;li class="h-as-share">
-      &lt;link class="u-author"
-        href="acct:sally@example.org">
-          Sally
-      &lt;link>
-      shared
-      &lt;a class="u-share-of"
-        href="http://example.org/posts/1">
-        http://example.org/posts/1
-      &lt;/a>
-      with
-      &lt;link class="u-as-target"
-        href="acct:john@example.org">
-          John
-      &lt;link>
-      &lt;link class="u-as-context"
-        href="http://example.org/contexts/1" />
-    &lt;/li>
-    &lt;li class="h-as-like">
-      &lt;link class="u-author"
-        href="acct:joe@example.org">
-          Joe
-      &lt;link>
-      liked
-      &lt;a class="u-like-of"
-        href="http://example.org/posts/1">
-        http://example.org/posts/2
-      &lt;/a>
-      &lt;link class="u-as-context"
-        href="http://example.org/contexts/1" />
-    &lt;/li>
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex171-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -9561,7 +8412,7 @@ _:b2 a as:Like ;
     <li><a href="#ex71-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex71-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex71-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex71-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex71-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex71-jsonld" style="display: block;">
@@ -9640,38 +8491,6 @@ _:b2 a as:Like ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex71-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="5" />
-  &lt;meta class="h-as-items-page-page" name="itemsPerPage"
-    content="3" />
-  &lt;a rel="current"
-    href="http://example.org/collection">
-    Most Recent Items&lt;/a>
-  &lt;ul class="p-as-items">
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/1">
-      http://example.org/posts/1
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/2">
-      http://example.org/posts/2
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/3">
-      http://example.org/posts/3
-    &lt;/a>
-    &lt;/li&gt;
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex71-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -9695,7 +8514,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex72-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex72-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex72-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex72-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex72-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex72-jsonld" style="display: block;">
@@ -9783,39 +8602,6 @@ _:b0 a as:Collection ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex72-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="5" />
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="3" />
-  &lt;a rel="current" class="h-entry"
-    href="http://example.org/collection">
-    &lt;span class="p-name">Most Recent Items&lt;/span>
-  &lt;/a>
-  &lt;ul class="p-as-items">
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/1">
-      http://example.org/posts/1
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/2">
-      http://example.org/posts/2
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/3">
-      http://example.org/posts/3
-    &lt;/a>
-    &lt;/li&gt;
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex72-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -9871,7 +8657,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex73-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex73-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex73-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex73-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex73-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex73-jsonld" style="display: block;">
@@ -9950,38 +8736,6 @@ _:b0 a as:Collection ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex73-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="5" />
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="3" />
-  &lt;a rel="first"
-    href="http://example.org/collection">
-    First Page&lt;/a>
-  &lt;ul class="p-as-items">
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/1">
-      http://example.org/posts/1
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/2">
-      http://example.org/posts/2
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/3">
-      http://example.org/posts/3
-    &lt;/a>
-    &lt;/li&gt;
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex73-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -10005,7 +8759,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex74-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex74-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex74-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex74-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex74-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex74-jsonld" style="display: block;">
@@ -10093,39 +8847,6 @@ _:b0 a as:Collection ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex74-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="5" />
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="3" />
-  &lt;a rel="first" class="h-entry"
-    href="http://example.org/collection">
-    &lt;span class="p-name">First Page&lt;/span>
-  &lt;/a>
-  &lt;ul class="p-as-items">
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/1">
-      http://example.org/posts/1
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/2">
-      http://example.org/posts/2
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/3">
-      http://example.org/posts/3
-    &lt;/a>
-    &lt;/li&gt;
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex74-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -10181,7 +8902,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex75-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex75-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex75-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex75-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex75-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex75-jsonld" style="display: block;">
@@ -10217,17 +8938,6 @@ _:b0 a as:Collection ;
   &lt;/span>
   (&lt;span property="generator" typeof="Application">
      &lt;span property="displayName">My Note Application&lt;/span>
-   &lt;/span>)
-&lt;/div></pre>
-  </div>
-  <div id="ex75-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="e-content">
-    A Simple Note
-  &lt;/span>
-  (&lt;span class="p-as-generator h-as-application" >
-     &lt;span class="p-name">My Note Application&lt;/span>
    &lt;/span>)
 &lt;/div></pre>
   </div>
@@ -10274,7 +8984,7 @@ _:b0 a as:Note ;
     <li><a href="#ex77-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex77-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex77-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex77-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex77-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex77-jsonld" style="display: block;">
@@ -10314,16 +9024,6 @@ _:b0 a as:Note ;
   &lt;span itemprop="content">A Simple Note&lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex77-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;img class="u-photo"
-    src="http://www.example.org/note.png"
-    alt="Note"
-    width="16px" height="16px" />
-  &lt;span class="e-content">A Simple Note&lt;/span>
-&lt;/div></pre>
-  </div>
   <div id="ex77-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -10347,7 +9047,7 @@ _:b0 a as:Note ;
     <li><a href="#ex78-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex78-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex78-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex78-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex78-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex78-jsonld" style="display: block;">
@@ -10396,17 +9096,6 @@ _:b0 a as:Note ;
     alt="Note"
     width="16px" height="16px" />
   &lt;span itemprop="content">A Simple Note&lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex78-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;img class="u-photo"
-    src="http://www.example.org/note1.png"
-    srcset="http://www.example.org/note2.png 2x"
-    alt="Note"
-    width="16px" height="16px" />
-  &lt;span class="e-content">A Simple Note&lt;/span>
 &lt;/div></pre>
   </div>
   <div id="ex78-turtle" style="display: none;">
@@ -10467,7 +9156,7 @@ _:b0 a as:Note ;
     <li><a href="#ex80-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex80-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex80-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex80-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex80-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex80-jsonld" style="display: block;">
@@ -10507,17 +9196,6 @@ _:b0 a as:Note ;
   &lt;/figure>
 &lt;/div></pre>
   </div>
-  <div id="ex80-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="e-content">A Simple Note&lt;/span>
-  &lt;figure class="p-photo h-entry" >
-    &lt;figcaption class="p-name">A Cat&lt;figcaption>
-    &lt;img class="u-url"
-      src="http://www.example.org/cat.png" />
-  &lt;/figure>
-&lt;/div></pre>
-  </div>
   <div id="ex80-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -10539,7 +9217,7 @@ _:b0 a as:Note ;
     <li><a href="#ex81-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex81-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex81-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex81-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex81-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex81-jsonld" style="display: block;">
@@ -10597,22 +9275,6 @@ _:b0 a as:Note ;
   &lt;/figure>
 &lt;/div></pre>
   </div>
-  <div id="ex81-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="e-content">A Simple Note&lt;/span>
-  &lt;figure class="p-photo h-entry">
-    &lt;figcaption class="p-name">Cat 1&lt;figcaption>
-    &lt;img class="u-url"
-      src="http://www.example.org/cat1.png" />
-  &lt;/figure>
-  &lt;figure class="p-photo h-entry">
-    &lt;figcaption class="p-name">Cat 2&lt;figcaption>
-    &lt;img class="u-url"
-      src="http://www.example.org/cat2.png" />
-  &lt;/figure>
-&lt;/div></pre>
-  </div>
   <div id="ex81-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -10666,7 +9328,7 @@ _:b0 a as:Note ;
     <li><a href="#ex83-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex83-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex83-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex83-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex83-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex83-jsonld" style="display: block;">
@@ -10703,16 +9365,6 @@ _:b0 a as:Note ;
   &lt;/span>"
 &lt;/div></pre>
   </div>
-  <div id="ex83-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  "&lt;span class="e-content">A simple note&lt;/span>
-  in reply to
-  "&lt;span class="p-in-reply-to h-entry">
-    "&lt;span class="e-content">Another note&lt;/span>"
-  &lt;/span>"
-&lt;/div></pre>
-  </div>
   <div id="ex83-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -10732,7 +9384,7 @@ _:b0 a as:Note ;
     <li><a href="#ex84-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex84-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex84-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex84-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex84-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex84-jsonld" style="display: block;">
@@ -10762,17 +9414,6 @@ _:b0 a as:Note ;
   "&lt;span property="content">A simple note&lt;/span>
   in reply to
   &lt;a property="inReplyTo"
-    href="http://example.org/posts/1">
-      http://example.org/posts/1
-  &lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex84-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  "&lt;span class="e-content">A simple note&lt;/span>
-  in reply to
-  &lt;a class="u-in-reply-to"
     href="http://example.org/posts/1">
       http://example.org/posts/1
   &lt;/a>
@@ -10818,7 +9459,7 @@ _:b0 a as:Note ;
     <li><a href="#ex87-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex87-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex87-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex87-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex87-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex87-jsonld" style="display: block;">
@@ -10897,38 +9538,6 @@ _:b0 a as:Note ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex87-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="5" />
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="3" />
-  &lt;a rel="last"
-    href="http://example.org/collection">
-    Last Page&lt;/a>
-  &lt;ul class="p-as-items">
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/1">
-      http://example.org/posts/1
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/2">
-      http://example.org/posts/2
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/3">
-      http://example.org/posts/3
-    &lt;/a>
-    &lt;/li&gt;
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex87-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -10952,7 +9561,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex88-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex88-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex88-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex88-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex88-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex88-jsonld" style="display: block;">
@@ -11040,39 +9649,6 @@ _:b0 a as:Collection ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex88-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="5" />
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="3" />
-  &lt;a rel="last" class="h-entry"
-    href="http://example.org/collection">
-    &lt;span class="p-name">Last Page&lt;/span>
-  &lt;/a>
-  &lt;ul class="p-as-items">
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/1">
-      http://example.org/posts/1
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/2">
-      http://example.org/posts/2
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/3">
-      http://example.org/posts/3
-    &lt;/a>
-    &lt;/li&gt;
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex88-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -11128,7 +9704,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex89-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex89-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex89-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex89-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex89-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex89-jsonld" style="display: block;">
@@ -11180,22 +9756,6 @@ _:b0 a as:Collection ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex89-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-card">
-  &lt;span class="p-name">Sally&lt;/span>
-  is at
-  &lt;span class="p-location h-geo">
-    Latitude
-    &lt;span class="p-latitude">56.78&lt;/span>,
-    Longitude
-    &lt;span class="p-longitude">12.34&lt;/span>,
-    at an altitude of
-    &lt;span class="p-altitude">90&lt;/span>
-    &lt;meta class="p-as-units" content="m">meters&lt;/meta>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
   <div id="ex89-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -11243,7 +9803,7 @@ _:b0 a as:Person ;
     <li><a href="#ex91-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex91-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex91-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex91-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex91-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex91-jsonld" style="display: block;">
@@ -11306,23 +9866,6 @@ _:b0 a as:Person ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex91-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="2" /&lt;
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="2" /&gt;
-  &lt;ul class="p-as-items">
-    &lt;li class="h-entry p-name">
-      A Simple Note
-    &lt;/li>
-    &lt;li class="h-entry p-name">
-      Another Simple Note
-    &lt;/li>
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex91-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -11350,7 +9893,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex92-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex92-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex92-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex92-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex92-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex92-jsonld" style="display: block;">
@@ -11416,25 +9959,6 @@ _:b0 a as:Collection ;
   &lt;/ol>
 &lt;/div></pre>
   </div>
-  <div id="ex92-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="2" /&lt;
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="2" /&gt;
-  &lt;meta class="p-as-start-index" name="startIndex"
-    content="0" /&gt;
-  &lt;ol class="p-as-items">
-    &lt;li class="h-entry p-name">
-      A Simple Note
-    &lt;/li>
-    &lt;li class="h-entry p-name">
-      Another Simple Note
-    &lt;/li>
-  &lt;/ol>
-&lt;/div></pre>
-  </div>
   <div id="ex92-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -11494,7 +10018,7 @@ _:b0 a as:OrderedCollection ;
     <li><a href="#ex93-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex93-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex93-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex93-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex93-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex93-jsonld" style="display: block;">
@@ -11550,22 +10074,6 @@ _:b0 a as:OrderedCollection ;
   &lt;ul&gt;
 &lt;/div></pre>
   </div>
-  <div id="ex93-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-question">
-  &lt;h2 class="p-name">
-    What is the answer?
-  &lt;/h2>
-  &lt;ul class="p-as-one-of"&gt;
-    &lt;li class="h-entry"&gt;
-      &lt;span class-"p-name">Option A&lt;/span&gt;
-    &lt;/li&gt;
-    &lt;li class="h-entry"&gt;
-      &lt;span class-"p-name">Option B&lt;/span&gt;
-    &lt;/li&gt;
-  &lt;ul&gt;
-&lt;/div></pre>
-  </div>
 <div id="ex93-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -11616,7 +10124,7 @@ _:b0 a as:Question ;
     <li><a href="#ex94-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex94-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex94-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex94-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex94-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex94-jsonld" style="display: block;">
@@ -11672,22 +10180,6 @@ _:b0 a as:Question ;
   &lt;ul&gt;
 &lt;/div></pre>
   </div>
-  <div id="ex94-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-question">
-  &lt;h2 class="p-name">
-    What is the answer?
-  &lt;/h2>
-  &lt;ul class="p-as-any-of"&gt;
-    &lt;li class="h-entry"&gt;
-      &lt;span class-"p-name">Option A&lt;/span&gt;
-    &lt;/li&gt;
-    &lt;li class="h-entry"&gt;
-      &lt;span class-"p-name">Option B&lt;/span&gt;
-    &lt;/li&gt;
-  &lt;ul&gt;
-&lt;/div></pre>
-  </div>
 <div id="ex94-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -11738,7 +10230,7 @@ _:b0 a as:Question ;
     <li><a href="#ex166-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex166-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex166-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex166-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex166-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex166-jsonld" style="display: block;">
@@ -11805,26 +10297,6 @@ _:b0 a as:Question ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex166-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-move">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">Sally&lt;link>
-  moved
-  &lt;a class="u-item"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  to
-  &lt;span class="p-as-target h-as-collection">
-    &lt;span class="p-name">List B&lt;/span>
-  &lt;/span>
-  from
-  &lt;span class="p-as-origin h-as-collection">
-    &lt;span class="p-name">List A&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
   <div id="ex166-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -11876,7 +10348,7 @@ _:b0 a as:Move ;
     <li><a href="#ex96-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex96-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex96-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex96-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex96-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex96-jsonld" style="display: block;">
@@ -11955,38 +10427,6 @@ _:b0 a as:Move ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex96-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="5" />
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="3" />
-  &lt;a rel="next"
-    href="http://example.org/collection">
-    Next Page&lt;/a>
-  &lt;ul class="p-as-items">
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/1">
-      http://example.org/posts/1
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/2">
-      http://example.org/posts/2
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/3">
-      http://example.org/posts/3
-    &lt;/a>
-    &lt;/li&gt;
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex96-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt .
@@ -12010,7 +10450,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex97-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex97-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex97-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex97-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex97-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex97-jsonld" style="display: block;">
@@ -12098,39 +10538,6 @@ _:b0 a as:Collection ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex97-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="5" />
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="3" />
-  &lt;a rel="next"
-    href="http://example.org/collection">
-    &lt;span class="p-name">Next Page&lt;/span>
-  &lt;/a>
-  &lt;ul class="p-as-items">
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/1">
-      http://example.org/posts/1
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/2">
-      http://example.org/posts/2
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/3">
-      http://example.org/posts/3
-    &lt;/a>
-    &lt;/li&gt;
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex97-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt .
@@ -12186,7 +10593,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex98-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex98-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex98-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex98-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex98-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex98-jsonld" style="display: block;">
@@ -12223,18 +10630,6 @@ _:b0 a as:Collection ;
   &lt;/a>
 &lt;/div></pre>
   </div>
-  <div id="ex98-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-like">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">Sally&lt;/link>
-  liked
-  &lt;a class="u-like-of"
-    href="http://example.org/posts/1">
-    "http://example.org/posts/1"
-  &lt;/a>
-&lt;/div></pre>
-  </div>
 <div id="ex98-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -12250,7 +10645,7 @@ _:b0 a as:Like
     <li><a href="#ex99-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex99-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex99-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex99-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex99-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex99-jsonld" style="display: block;">
@@ -12293,19 +10688,6 @@ _:b0 a as:Like
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex99-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-like">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">Sally&lt;/link>
-  liked
-  &lt;span class="p-like-of h-entry">
-    "&lt;span class="e-content">
-      A simple note
-    &lt;/span>"
-  &lt;/span>
-&lt;/div></pre>
-  </div>
 <div id="ex99-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -12324,7 +10706,7 @@ _:b0 a as:Like
     <li><a href="#ex100-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex100-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex100-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex100-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex100-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex100-jsonld" style="display: block;">
@@ -12378,23 +10760,6 @@ _:b0 a as:Like
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex100-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-like">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">Sally&lt;/link>
-  liked
-  &lt;link class="u-like-of"
-    href="http://example.org/posts/1">
-    "http://example.org/posts/1"
-  &lt;/link> and
-  &lt;span class="p-like-of h-entry">
-    "&lt;span class="e-content">
-      A simple note
-    &lt;/span>"
-  &lt;/span>
-&lt;/div></pre>
-  </div>
 <div id="ex100-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -12441,7 +10806,7 @@ _:b0 a as:Like
     <li><a href="#ex104-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex104-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex104-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex104-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex104-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex104-jsonld" style="display: block;">
@@ -12520,38 +10885,6 @@ _:b0 a as:Like
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex104-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="5" />
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="3" />
-  &lt;a rel="prev"
-    href="http://example.org/collection">
-    Previous Page&lt;/a>
-  &lt;ul class="p-as-items">
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/1">
-      http://example.org/posts/1
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/2">
-      http://example.org/posts/2
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/3">
-      http://example.org/posts/3
-    &lt;/a>
-    &lt;/li&gt;
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex104-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt .
@@ -12575,7 +10908,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex105-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex105-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex105-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex105-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex105-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex105-jsonld" style="display: block;">
@@ -12663,39 +10996,6 @@ _:b0 a as:Collection ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex105-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="5" />
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="3" />
-  &lt;a rel="prev"
-    href="http://example.org/collection">
-    &lt;span class="p-name">Previous Page&lt;/span>
-  &lt;/a>
-  &lt;ul class="p-as-items">
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/1">
-      http://example.org/posts/1
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/2">
-      http://example.org/posts/2
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/3">
-      http://example.org/posts/3
-    &lt;/a>
-    &lt;/li&gt;
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex105-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt .
@@ -12751,7 +11051,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex106-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex106-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex106-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex106-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex106-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex106-jsonld" style="display: block;">
@@ -12804,22 +11104,6 @@ _:b0 a as:Collection ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex106-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="p-name">Cool New Movie&lt;/span>
-  &lt;meta class="p-as-duration" name="duration"
-    content="PT2H30M">(2H 30M)&lt;/meta>
-  - &lt;span class="p-preview h-entry">
-      &lt;span class="p-name">Trailer&lt;span>
-      &lt;meta class="p-as-duration" name="duration"
-        content="PT1M">(1M)&lt;/meta>
-      &lt;a class="u-url"
-        href="http://example.org/trailer.mkv"
-        type="video/mkv">Watch&lt;/a>
-    &lt;/span>
-&lt;/div></pre>
-  </div>
 <div id="ex106-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -12866,7 +11150,7 @@ _:b0 a as:Movie ;
     <li><a href="#ex108-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex108-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex108-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex108-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex108-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex108-jsonld" style="display: block;">
@@ -12915,19 +11199,6 @@ _:b0 a as:Movie ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex108-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-activity h-x-check">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">Sally's&lt;/link>
-  &lt;link class="u-item"
-    href="http://example.org/flights/1">flight&lt;/link>
-  is
-  &lt;span class="p-as-result h-entry">
-    &lt;span class="p-name">On Time&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
 <div id="ex108-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -12973,7 +11244,7 @@ _:b0 a as:Activity,
     <li><a href="#ex112-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex112-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex112-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex112-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex112-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex112-jsonld" style="display: block;">
@@ -13043,27 +11314,6 @@ _:b0 a as:Activity,
   &lt;/div>
 &lt;/div></pre>
   </div>
-  <div id="ex112-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;div class="e-content">A simple note&lt;/div>
-  &lt;div class="p-as-replies h-as-collection">
-    &lt;meta class="p-as-total-items" name="totalItems"
-      content="1" /&gt;
-    &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-      content="1" /&gt;
-    &lt;ul class="p-as-items">
-      &lt;li class="h-entry">
-        &lt;span class="e-content">
-          A response to the note
-        &lt;/span>
-        &lt;link rel="u-in-reply-to"
-          href="urn:example:notes:1" /&gt;
-      &lt;/li>
-    &lt;/ul>
-  &lt;/div>
-&lt;/div></pre>
-  </div>
   <div id="ex112-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -13118,7 +11368,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex113-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex113-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex113-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex113-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex113-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex113-jsonld" style="display: block;">
@@ -13156,17 +11406,6 @@ _:b0 a as:Collection ;
   &lt;/div>
   &lt;div property="scope" typeof="http://example.org/Organization">
     &lt;span property="displayName">
-      My Organization
-    &lt;/span>
-  &lt;/div>
-&lt;/div></pre>
-  </div>
-  <div id="ex113-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;div class="e-content">A simple note&lt;/div>
-  &lt;div class="p-as-scope h-entru">
-    &lt;span class="p-name">
       My Organization
     &lt;/span>
   &lt;/div>
@@ -13216,7 +11455,7 @@ _:b0 a as:Note ;
     <li><a href="#ex115-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex115-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex115-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex115-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex115-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex115-jsonld" style="display: block;">
@@ -13295,38 +11534,6 @@ _:b0 a as:Note ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex115-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="5" />
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="3" />
-  &lt;a rel="self"
-    href="http://example.org/collection">
-    This Page&lt;/a>
-  &lt;ul class="p-as-items">
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/1">
-      http://example.org/posts/1
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/2">
-      http://example.org/posts/2
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/3">
-      http://example.org/posts/3
-    &lt;/a>
-    &lt;/li&gt;
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex115-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt .
@@ -13350,7 +11557,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex116-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex116-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex116-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex116-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex116-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex116-jsonld" style="display: block;">
@@ -13438,39 +11645,6 @@ _:b0 a as:Collection ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex116-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="5" />
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="3" />
-  &lt;a rel="self" class="h-entry"
-    href="http://example.org/collection">
-    &lt;span class="p-name">This Page&lt;/span>
-  &lt;/a>
-  &lt;ul class="p-as-items">
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/1">
-      http://example.org/posts/1
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/2">
-      http://example.org/posts/2
-    &lt;/a>
-    &lt;/li&gt;
-    &lt;li&gt;
-    &lt;a class="h-entry u-url"
-      href="http://example.org/posts/3">
-      http://example.org/posts/3
-    &lt;/a>
-    &lt;/li&gt;
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex116-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt .
@@ -13525,7 +11699,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex118-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex118-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex118-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex118-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex118-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex118-jsonld" style="display: block;">
@@ -13568,19 +11742,6 @@ _:b0 a as:Collection ;
     &lt;/span>
   &lt;/figcaption>
   &lt;img property="url"
-    src="http://example.org/sally.jpg" />
-&lt;/figure></pre>
-  </div>
-  <div id="ex118-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;figure class="h-entry">
-  &lt;figcaption class="p-name">
-    Picture of
-    &lt;span class="p-as-tag h-card">
-      &lt;span class="p-name">Sally&lt;/span>
-    &lt;/span>
-  &lt;/figcaption>
-  &lt;img class="u-url"
     src="http://example.org/sally.jpg" />
 &lt;/figure></pre>
   </div>
@@ -13630,7 +11791,7 @@ _:b0 a as:Image ;
     <li><a href="#ex120-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex120-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex120-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex120-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex120-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex120-jsonld" style="display: block;">
@@ -13682,25 +11843,6 @@ _:b0 a as:Image ;
   &lt;/link>
 &lt;/div></pre>
   </div>
-  <div id="ex120-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">
-      Sally
-  &lt;link>
-  shared
-  &lt;a class="u-share-of"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link class="u-as-target"
-    href="acct:sally@example.org">
-      John
-  &lt;link>
-&lt;/div></pre>
-  </div>
   <div id="ex120-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -13718,7 +11860,7 @@ _:b0 a as:Share ;
     <li><a href="#ex121-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex121-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex121-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex121-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex121-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex121-jsonld" style="display: block;">
@@ -13773,24 +11915,6 @@ _:b0 a as:Share ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex121-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">
-      Sally
-  &lt;link>
-  shared
-  &lt;a class="u-share-of"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;span class="p-as-target">
-    &lt;span class="p-name">John&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
   <div id="ex121-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -13839,7 +11963,7 @@ _:b0 a as:Share ;
     <li><a href="#ex123-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex123-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex123-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex123-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex123-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex123-jsonld" style="display: block;">
@@ -13900,27 +12024,6 @@ _:b0 a as:Share ;
   &lt;/link>)
 &lt;/div></pre>
   </div>
-  <div id="ex123-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;link class="u-author
-    href="acct:sally@example.org">Sally&lt;link>
-  shared
-  &lt;a class="u-share-of"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link class="u-as-target"
-    href="acct:sally@example.org">
-      John
-  &lt;link>
-  (to: &lt;link class="u-as-to"
-    href="acct:joe@example.org">
-    John
-  &lt;/link>)
-&lt;/div></pre>
-  </div>
   <div id="ex123-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt .
@@ -13963,7 +12066,7 @@ _:b0 a as:Share ;
     <li><a href="#ex124-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex124-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex124-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex124-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex124-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex124-jsonld" style="display: block;">
@@ -13992,15 +12095,6 @@ _:b0 a as:Share ;
     href="http://example.org/4q-sales-forecast.pdf">Open&lt;/a>
 &lt;/div></pre>
   </div>
-  <div id="ex124-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-&lt;span class="p-name">4Q Sales Forecast&lt;/span> -
-  &lt;a class="u-url"
-    href="http://example.org/4q-sales-forecast.pdf">Open&lt;/a>
-&lt;/div>
-&lt;/div></pre>
-  </div>
 <div id="ex124-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -14016,7 +12110,7 @@ _:b0 a as:Document ;
     <li><a href="#ex125-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex125-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex125-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex125-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex125-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex125-jsonld" style="display: block;">
@@ -14049,14 +12143,6 @@ _:b0 a as:Document ;
     href="http://example.org/4q-sales-forecast.pdf">Open&lt;/a>
 &lt;/div></pre>
   </div>
-  <div id="ex125-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-&lt;span class="p-name">4Q Sales Forecast&lt;/span> -
-  &lt;a class="u-url"
-    href="http://example.org/4q-sales-forecast.pdf">Open&lt;/a>
-&lt;/div></pre>
-  </div>
 <div id="ex125-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -14075,7 +12161,7 @@ _:b0 a as:Document ;
     <li><a href="#ex126-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex126-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex126-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex126-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex126-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex126-jsonld" style="display: block;">
@@ -14121,18 +12207,6 @@ _:b0 a as:Document ;
     href="http://example.org/4q-sales-forecast.pdf"
     type="application/pdf">PDF&lt;/a> |
   &lt;a property="url" typeof="Link"
-    href="http://example.org/4q-sales-forecast.html"
-    type="text/html">HTML&lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex126-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-&lt;span class="p-name">4Q Sales Forecast&lt;/span> -
-  &lt;a class="u-url"
-    href="http://example.org/4q-sales-forecast.pdf"
-    type="application/pdf">PDF&lt;/a>  |
-  &lt;a class="u-url"
     href="http://example.org/4q-sales-forecast.html"
     type="text/html">HTML&lt;/a>
 &lt;/div></pre>
@@ -14187,7 +12261,7 @@ _:b0 a as:Document ;
     <li><a href="#ex127-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex127-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex127-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex127-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex127-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex127-jsonld" style="display: block;">
@@ -14232,23 +12306,6 @@ _:b0 a as:Document ;
   &lt;tr>
     &lt;td>Accuracy&lt;/td>
     &lt;td property="accuracy">94.5&lt;/td>
-  &lt;/tr>
-&lt;/table></pre>
-  </div>
-  <div id="ex127-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;table class="h-geo">
-  &lt;tr>
-    &lt;td>Latitude&lt;/td>
-    &lt;td class="p-latitude">36.75&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Longitude&lt;/td>
-    &lt;td class="p-longitude">119.7667&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Accuracy&lt;/td>
-    &lt;td class="p-as-accuracy">94.5&lt;/td>
   &lt;/tr>
 &lt;/table></pre>
   </div>
@@ -14298,7 +12355,7 @@ _:b0 a as:Place ;
     <li><a href="#ex128-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex128-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex128-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex128-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex128-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex128-jsonld" style="display: block;">
@@ -14334,19 +12391,6 @@ _:b0 a as:Place ;
   &lt;tr>
     &lt;td>Alias&lt;/td>
     &lt;td property="alias">@home&lt;/td>
-  &lt;/tr>
-&lt;/table></pre>
-  </div>
-  <div id="ex128-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;table class="h-entry">
-  &lt;tr>
-    &lt;td>Name&lt;/td>
-    &lt;td class="p-name">Home&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Alias&lt;/td>
-    &lt;td class="p-as-alias">@home&lt;/td>
   &lt;/tr>
 &lt;/table></pre>
   </div>
@@ -14403,7 +12447,7 @@ _:b0 a as:Place ;
     <li><a href="#ex129-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex129-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex129-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex129-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex129-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex129-jsonld" style="display: block;">
@@ -14469,31 +12513,6 @@ _:b0 a as:Place ;
   &lt;/tr>
 &lt;/table></pre>
   </div>
-  <div id="ex129-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;table class="h-geo">
-  &lt;tr>
-    &lt;td>Name&lt;/td>
-    &lt;td class="p-name">Fresno Area&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Latitude&lt;/td>
-    &lt;td class="p-latitude">36.75&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Longitude&lt;/td>
-    &lt;td class="p-longitude">119.7667&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Altitude&lt;/td>
-    &lt;td class="p-altitude">15&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Units&lt;/td>
-    &lt;td class="p-as-units">miles&lt;/td>
-  &lt;/tr>
-&lt;/table></pre>
-  </div>
 <div id="ex129-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -14543,7 +12562,7 @@ _:b0 a as:Place ;
     <li><a href="#ex130-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex130-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex130-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex130-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex130-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex130-jsonld" style="display: block;">
@@ -14571,14 +12590,6 @@ _:b0 a as:Place ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex130-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="e-content">
-    A simple note
-  &lt;/span
-&lt;/div></pre>
-  </div>
 <div id="ex130-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -14594,7 +12605,7 @@ _:b0 a as:Note ;
     <li><a href="#ex131-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex131-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex131-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex131-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex131-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex131-jsonld" style="display: block;">
@@ -14627,17 +12638,6 @@ _:b0 a as:Note ;
     A simple note
   &lt;/span>
   &lt;span property="content" lang="sp">
-    Una simple nota
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex131-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="e-content" lang="en">
-    A simple note
-  &lt;/span
-  &lt;span class="e-content" lang="sp">
     Una simple nota
   &lt;/span>
 &lt;/div></pre>
@@ -14683,7 +12683,7 @@ _:b0 a as:Note ;
     <li><a href="#ex132-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex132-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex132-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex132-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex132-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex132-jsonld" style="display: block;">
@@ -14711,14 +12711,6 @@ _:b0 a as:Note ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex132-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="p-name">
-    A simple note
-  &lt;/span
-&lt;/div></pre>
-  </div>
 <div id="ex132-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -14734,7 +12726,7 @@ _:b0 a as:Note ;
     <li><a href="#ex133-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex133-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex133-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex133-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex133-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex133-jsonld" style="display: block;">
@@ -14767,17 +12759,6 @@ _:b0 a as:Note ;
     A simple note
   &lt;/span>
   &lt;span property="displayName" lang="sp">
-    Una simple nota
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex133-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="p-name" lang="en">
-    A simple note
-  &lt;/span
-  &lt;span class="p-name" lang="sp">
     Una simple nota
   &lt;/span>
 &lt;/div></pre>
@@ -14823,7 +12804,7 @@ _:b0 a as:Note ;
     <li><a href="#ex134-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex134-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex134-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex134-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex134-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex134-jsonld" style="display: block;">
@@ -14855,16 +12836,6 @@ _:b0 a as:Note ;
     href="http://example.org/video.mkv">Watch&lt;a>
 &lt;/div></pre>
   </div>
-  <div id="ex134-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-&lt;span class="p-name">A Simple Video&lt;/span>
-  &lt;meta class="p-as-duration" name="duration"
-    content="PT2H">(2 hours)&lt;meta> -
-  &lt;a class="u-url"
-    href="http://example.org/video.mkv">Watch&lt;a>
-&lt;/div></pre>
-  </div>
 <div id="ex134-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -14882,7 +12853,7 @@ _:b0 a as:Video ;
     <li><a href="#ex135-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex135-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex135-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex135-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex135-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex135-jsonld" style="display: block;">
@@ -14911,16 +12882,6 @@ _:b0 a as:Video ;
 &lt;span property="displayName">A Simple Video&lt;/span>
   &lt;meta property="duration" content="3600">(2 hours)&lt;meta> -
   &lt;a property="url"
-    href="http://example.org/video.mkv">Watch&lt;a>
-&lt;/div></pre>
-  </div>
-  <div id="ex135-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-&lt;span class="p-name">A Simple Video&lt;/span>
-  &lt;meta class="p-as-duration" name="duration"
-    content="3600">(2 hours)&lt;meta> -
-  &lt;a class="u-url"
     href="http://example.org/video.mkv">Watch&lt;a>
 &lt;/div></pre>
   </div>
@@ -14974,7 +12935,7 @@ _:b0 a as:Video ;
     <li><a href="#ex136-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex136-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex136-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex136-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex136-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex136-jsonld" style="display: block;">
@@ -15010,15 +12971,6 @@ _:b0 a as:Video ;
   &lt;/div>
   &lt;meta property="height" content="100" />
   &lt;meta property="width" content="100" />
-&lt;/div></pre>
-  </div>
-  <div id="ex136-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry" style="width:100px; height:100px">
-  &lt;div property="p-name">Some generic content&lt;/div>
-  &lt;div property="e-content">
-    &lt;p>This can be any kind of content&lt;/p>
-  &lt;/div>
 &lt;/div></pre>
   </div>
 <div id="ex136-turtle" style="display: none;">
@@ -15069,7 +13021,7 @@ _:b0 a as:Content ;
     <li><a href="#ex137-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex137-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex137-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex137-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex137-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex137-jsonld" style="display: block;">
@@ -15099,13 +13051,6 @@ _:b0 a as:Content ;
     hreflang="en"
     type="text/html"
     property="displayName">An example link&lt;/a></pre>
-  </div>
-  <div id="ex137-microformats" style="display: none;">
-<pre class="example highlight json"
->&lt;a class="h-entry p-name"
-    href="http://example.org/abc"
-    hreflang="en"
-    type="text/html">An example link&lt;/a></pre>
   </div>
   <div id="ex137-turtle" style="display: none;">
 <pre class="example highlight turtle"
@@ -15152,7 +13097,7 @@ _:b0 a as:Link ;
     <li><a href="#ex138-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex138-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex138-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex138-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex138-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex138-jsonld" style="display: block;">
@@ -15182,13 +13127,6 @@ _:b0 a as:Link ;
     hreflang="en"
     type="text/html"
     property="displayName">An example link&lt;/a></pre>
-  </div>
-  <div id="ex138-microformats" style="display: none;">
-<pre class="example highlight json"
->&lt;a class="h-entry p-name"
-    href="http://example.org/abc"
-    hreflang="en"
-    type="text/html">An example link&lt;/a></pre>
   </div>
   <div id="ex138-turtle" style="display: none;">
 <pre class="example highlight turtle"
@@ -15238,7 +13176,7 @@ _:b0 a as:Link ;
     <li><a href="#ex139-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex139-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex139-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex139-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex139-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex139-jsonld" style="display: block;">
@@ -15301,23 +13239,6 @@ _:b0 a as:Link ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex139-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="2" /&lt;
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="2" /&gt;
-  &lt;ul class="p-as-items">
-    &lt;li class="h-entry p-name">
-      A Simple Note
-    &lt;/li>
-    &lt;li class="h-entry p-name">
-      Another Simple Note
-    &lt;/li>
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex139-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -15374,7 +13295,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex140-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex140-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex140-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex140-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex140-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex140-jsonld" style="display: block;">
@@ -15440,31 +13361,6 @@ _:b0 a as:Collection ;
   &lt;/tr>
 &lt;/table></pre>
   </div>
-  <div id="ex140-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;table class="h-geo">
-  &lt;tr>
-    &lt;td>Name&lt;/td>
-    &lt;td class="p-name">Fresno Area&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Latitude&lt;/td>
-    &lt;td class="p-latitude">36.75&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Longitude&lt;/td>
-    &lt;td class="p-longitude">119.7667&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Radius&lt;/td>
-    &lt;td class="p-as-radius">15&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Units&lt;/td>
-    &lt;td class="p-as-units">miles&lt;/td>
-  &lt;/tr>
-&lt;/table></pre>
-  </div>
 <div id="ex140-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -15511,7 +13407,7 @@ _:b0 a as:Place ;
     <li><a href="#ex141-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex141-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex141-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex141-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex141-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex141-jsonld" style="display: block;">
@@ -15577,31 +13473,6 @@ _:b0 a as:Place ;
   &lt;/tr>
 &lt;/table></pre>
   </div>
-  <div id="ex141-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;table class="h-geo">
-  &lt;tr>
-    &lt;td>Name&lt;/td>
-    &lt;td class="p-name">Fresno Area&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Latitude&lt;/td>
-    &lt;td class="p-latitude">36.75&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Longitude&lt;/td>
-    &lt;td class="p-longitude">119.7667&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Radius&lt;/td>
-    &lt;td class="p-as-radius">15&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Units&lt;/td>
-    &lt;td class="p-as-units">miles&lt;/td>
-  &lt;/tr>
-&lt;/table></pre>
-  </div>
 <div id="ex141-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -15648,7 +13519,7 @@ _:b0 a as:Place ;
     <li><a href="#ex142-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex142-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex142-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex142-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex142-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex142-jsonld" style="display: block;">
@@ -15678,13 +13549,6 @@ _:b0 a as:Place ;
     hreflang="en"
     type="text/html"
     property="displayName">An example link&lt;/a></pre>
-  </div>
-  <div id="ex142-microformats" style="display: none;">
-<pre class="example highlight json"
->&lt;a class="h-entry p-name"
-    href="http://example.org/abc"
-    hreflang="en"
-    type="text/html">An example link&lt;/a></pre>
   </div>
   <div id="ex142-turtle" style="display: none;">
 <pre class="example highlight turtle"
@@ -15732,7 +13596,7 @@ _:b0 a as:Link ;
     <li><a href="#ex143-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex143-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex143-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex143-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex143-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex143-jsonld" style="display: block;">
@@ -15785,24 +13649,6 @@ _:b0 a as:Link ;
     John
   &lt;/link>
   &lt;meta property="priority" content="0.80" />
-&lt;/div></pre>
-  </div>
-  <div id="ex143-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;link class="u-author"
-    href="acct:sally@example.org">Sally&lt;link>
-  shared
-  &lt;a class="u-item"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link class="u-as-target"
-    href="acct:sally@example.org">
-      John
-  &lt;link>
-  &lt;meta name="p-as-priority" content="0.80" />
 &lt;/div></pre>
   </div>
   <div id="ex143-turtle" style="display: none;">
@@ -15893,7 +13739,7 @@ _:b0 a as:Share ;
     <li><a href="#ex144-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex144-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex144-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex144-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex144-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex144-jsonld" style="display: block;">
@@ -15934,24 +13780,6 @@ _:b0 a as:Share ;
   &lt;/div>
   &lt;div>Ends:
   &lt;meta property="endTime" content="2015-01-01T06:00:00-08:00">
-    06:00 AM on Jan 1, 2015
-  &lt;/meta>
-  &lt;/div>
-&lt;/div></pre>
-  </div>
-  <div id="ex144-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-event">
-  &lt;h2 class="p-name">A Party&lt;/h2>
-  &lt;div>Starts:
-  &lt;meta class="dt-start" name="startTime"
-    content="2014-12-31T23:00:00-08:00">
-    11:00 PM on Dec 31, 2014
-  &lt;/meta>
-  &lt;/div>
-  &lt;div>Ends:
-  &lt;meta class="dt-end" name="endTime"
-    content="2015-01-01T06:00:00-08:00">
     06:00 AM on Jan 1, 2015
   &lt;/meta>
   &lt;/div>
@@ -16004,7 +13832,7 @@ _:b0 a as:Event ;
     <li><a href="#ex145-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex145-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex145-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex145-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex145-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex145-jsonld" style="display: block;">
@@ -16034,16 +13862,6 @@ _:b0 a as:Event ;
     A simple note
   &lt;/div>
   &lt;meta property="published"
-    content="2014-12-12T12:12:12Z" />
-&lt;/div></pre>
-  </div>
-  <div id="ex145-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;div class="e-content">
-    A simple note
-  &lt;/div>
-  &lt;meta class="dt-published" name="published"
     content="2014-12-12T12:12:12Z" />
 &lt;/div></pre>
   </div>
@@ -16090,7 +13908,7 @@ _:b0 a as:Note ;
     <li><a href="#ex146-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex146-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex146-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex146-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex146-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex146-jsonld" style="display: block;">
@@ -16131,24 +13949,6 @@ _:b0 a as:Note ;
   &lt;/div>
   &lt;div>Ends:
   &lt;meta property="endTime" content="2015-01-01T06:00:00-08:00">
-    06:00 AM on Jan 1, 2015
-  &lt;/meta>
-  &lt;/div>
-&lt;/div></pre>
-  </div>
-  <div id="ex146-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-event">
-  &lt;h2 class="p-name">A Party&lt;/h2>
-  &lt;div>Starts:
-  &lt;meta class="dt-start" name="startTime"
-    content="2014-12-31T23:00:00-08:00">
-    11:00 PM on Dec 31, 2014
-  &lt;/meta>
-  &lt;/div>
-  &lt;div>Ends:
-  &lt;meta class="dt-end" name="endTime"
-    content="2015-01-01T06:00:00-08:00">
     06:00 AM on Jan 1, 2015
   &lt;/meta>
   &lt;/div>
@@ -16201,7 +14001,7 @@ _:b0 a as:Event ;
     <li><a href="#ex147-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex147-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex147-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex147-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex147-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex147-jsonld" style="display: block;">
@@ -16267,31 +14067,6 @@ _:b0 a as:Event ;
   &lt;/tr>
 &lt;/table></pre>
   </div>
-  <div id="ex147-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;table class="h-geo">
-  &lt;tr>
-    &lt;td>Name&lt;/td>
-    &lt;td class="p-name">Fresno Area&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Latitude&lt;/td>
-    &lt;td class="p-latitude">36.75&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Longitude&lt;/td>
-    &lt;td class="p-longitude">119.7667&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Radius&lt;/td>
-    &lt;td class="p-as-radius">15&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Units&lt;/td>
-    &lt;td class="p-as-units">miles&lt;/td>
-  &lt;/tr>
-&lt;/table></pre>
-  </div>
 <div id="ex147-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -16341,7 +14116,7 @@ _:b0 a as:Place ;
     <li><a href="#ex149-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex149-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex149-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex149-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex149-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex149-jsonld" style="display: block;">
@@ -16374,14 +14149,6 @@ _:b0 a as:Place ;
     type="text/html"
     rel="canonical preview"
     property="displayName">An example link&lt;/a></pre>
-  </div>
-  <div id="ex149-microformats" style="display: none;">
-<pre class="example highlight json"
->&lt;a class="h-entry p-name"
-    href="http://example.org/abc"
-    hreflang="en"
-    rel="canonical preview"
-    type="text/html">An example link&lt;/a></pre>
   </div>
   <div id="ex149-turtle" style="display: none;">
 <pre class="example highlight turtle"
@@ -16430,7 +14197,7 @@ _:b0 a as:Link ;
     <li><a href="#ex150-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex150-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex150-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex150-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex150-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex150-jsonld" style="display: block;">
@@ -16496,25 +14263,6 @@ _:b0 a as:Link ;
   &lt;/ol>
 &lt;/div></pre>
   </div>
-  <div id="ex150-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="2" /&lt;
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="2" /&gt;
-  &lt;meta class="p-as-start-index" name="startIndex"
-    content="0" /&gt;
-  &lt;ol class="p-as-items">
-    &lt;li class="h-entry p-name">
-      A Simple Note
-    &lt;/li>
-    &lt;li class="h-entry p-name">
-      Another Simple Note
-    &lt;/li>
-  &lt;/ol>
-&lt;/div></pre>
-  </div>
   <div id="ex150-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -16575,7 +14323,7 @@ _:b0 a as:OrderedCollection ;
     <li><a href="#ex152-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex152-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex152-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex152-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex152-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex152-jsonld" style="display: block;">
@@ -16603,14 +14351,6 @@ _:b0 a as:OrderedCollection ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex152-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="p-summary">
-    A simple note
-  &lt;/span
-&lt;/div></pre>
-  </div>
 <div id="ex152-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -16626,7 +14366,7 @@ _:b0 a as:Note ;
     <li><a href="#ex153-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex153-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex153-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex153-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex153-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex153-jsonld" style="display: block;">
@@ -16659,17 +14399,6 @@ _:b0 a as:Note ;
     A simple note
   &lt;/span>
   &lt;span property="summary" lang="sp">
-    Una simple nota
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex153-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="p-summary" lang="en">
-    A simple note
-  &lt;/span
-  &lt;span class="p-summary" lang="sp">
     Una simple nota
   &lt;/span>
 &lt;/div></pre>
@@ -16716,7 +14445,7 @@ _:b0 a as:Note ;
     <li><a href="#ex154-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex154-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex154-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex154-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex154-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex154-jsonld" style="display: block;">
@@ -16744,14 +14473,6 @@ _:b0 a as:Note ;
   &lt;/span>
 &lt;/div></pre>
   </div>
-  <div id="ex154-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="p-title">
-    A simple note
-  &lt;/span
-&lt;/div></pre>
-  </div>
 <div id="ex154-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -16767,7 +14488,7 @@ _:b0 a as:Note ;
     <li><a href="#ex155-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex155-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex155-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex155-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex155-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex155-jsonld" style="display: block;">
@@ -16800,17 +14521,6 @@ _:b0 a as:Note ;
     A simple note
   &lt;/span>
   &lt;span property="title" lang="sp">
-    Una simple nota
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex155-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;span class="p-title" lang="en">
-    A simple note
-  &lt;/span
-  &lt;span class="p-title" lang="sp">
     Una simple nota
   &lt;/span>
 &lt;/div></pre>
@@ -16860,7 +14570,7 @@ _:b0 a as:Note ;
     <li><a href="#ex156-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex156-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex156-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex156-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex156-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex156-jsonld" style="display: block;">
@@ -16923,23 +14633,6 @@ _:b0 a as:Note ;
   &lt;/ul>
 &lt;/div></pre>
   </div>
-  <div id="ex156-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems"
-    content="2" /&lt;
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage"
-    content="2" /&gt;
-  &lt;ul class="p-as-items">
-    &lt;li class="h-entry p-name">
-      A Simple Note
-    &lt;/li>
-    &lt;li class="h-entry p-name">
-      Another Simple Note
-    &lt;/li>
-  &lt;/ul>
-&lt;/div></pre>
-  </div>
   <div id="ex156-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -16997,7 +14690,7 @@ _:b0 a as:Collection ;
     <li><a href="#ex157-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex157-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex157-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex157-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex157-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex157-jsonld" style="display: block;">
@@ -17063,31 +14756,6 @@ _:b0 a as:Collection ;
   &lt;/tr>
 &lt;/table></pre>
   </div>
-  <div id="ex157-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;table class="h-geo">
-  &lt;tr>
-    &lt;td>Name&lt;/td>
-    &lt;td class="p-name">Fresno Area&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Latitude&lt;/td>
-    &lt;td class="p-latitude">36.75&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Longitude&lt;/td>
-    &lt;td class="p-longitude">119.7667&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Radius&lt;/td>
-    &lt;td class="p-as-radius">15&lt;/td>
-  &lt;/tr>
-  &lt;tr>
-    &lt;td>Units&lt;/td>
-    &lt;td class="p-as-units">miles&lt;/td>
-  &lt;/tr>
-&lt;/table></pre>
-  </div>
 <div id="ex157-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -17146,7 +14814,7 @@ _:b0 a as:Place ;
     <li><a href="#ex158-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex158-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex158-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex158-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex158-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex158-jsonld" style="display: block;">
@@ -17176,16 +14844,6 @@ _:b0 a as:Place ;
     A simple note
   &lt;/div>
   &lt;meta property="updated"
-    content="2014-12-12T12:12:12Z" />
-&lt;/div></pre>
-  </div>
-  <div id="ex158-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;div class="e-content">
-    A simple note
-  &lt;/div>
-  &lt;meta class="dt-updated" name="updated"
     content="2014-12-12T12:12:12Z" />
 &lt;/div></pre>
   </div>
@@ -17232,7 +14890,7 @@ _:b0 a as:Note ;
     <li><a href="#ex159-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex159-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex159-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex159-microformats" class="selected">Microformats</a></li>
+
     <li><a href="#ex159-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex159-jsonld" style="display: block;">
@@ -17268,15 +14926,6 @@ _:b0 a as:Note ;
   &lt;/div>
   &lt;meta property="height" content="100" />
   &lt;meta property="width" content="100" />
-&lt;/div></pre>
-  </div>
-  <div id="ex159-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry" style="width:100px; height:100px">
-  &lt;div property="p-name">Some generic content&lt;/div>
-  &lt;div property="e-content">
-    &lt;p>This can be any kind of content&lt;/p>
-  &lt;/div>
 &lt;/div></pre>
   </div>
 <div id="ex159-turtle" style="display: none;">
@@ -17327,7 +14976,6 @@ _:b0 a as:Content ;
                 <li><a href="#ex22a-jsonld" class="selected">JSON-LD</a></li>
                 <li><a href="#ex22a-microdata" class="selected">Microdata</a></li>
                 <li><a href="#ex22a-rdfa" class="selected">RDFa</a></li>
-                <li><a href="#ex22a-microformats" class="selected">Microformats</a></li>
                 <li><a href="#ex22a-turtle" class="selected">Turtle</a></li>
               </ul>
               <div id="ex22a-jsonld" style="display: block;">
@@ -17376,18 +15024,6 @@ _:b0 a as:Content ;
   &lt;/span>
   &lt;span property="b" typeof="Person">
     &lt;span property="displayName">John&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex22a-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-connection">
-  &lt;span class="h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  knows
-  &lt;span class="h-card">
-    &lt;span class="p-name">John&lt;/span>
   &lt;/span>
 &lt;/div></pre>
   </div>
@@ -17444,7 +15080,6 @@ _:b0 a as:Connection ;
                 <li><a href="#ex22b-jsonld" class="selected">JSON-LD</a></li>
                 <li><a href="#ex22b-microdata" class="selected">Microdata</a></li>
                 <li><a href="#ex22b-rdfa" class="selected">RDFa</a></li>
-                <li><a href="#ex22b-microformats" class="selected">Microformats</a></li>
                 <li><a href="#ex22b-turtle" class="selected">Turtle</a></li>
               </ul>
               <div id="ex22b-jsonld" style="display: block;">
@@ -17493,18 +15128,6 @@ _:b0 a as:Connection ;
   &lt;/span>
   &lt;span property="b" typeof="Person">
     &lt;span property="displayName">John&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex22b-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-connection">
-  &lt;span class="h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  knows
-  &lt;span class="h-card">
-    &lt;span class="p-name">John&lt;/span>
   &lt;/span>
 &lt;/div></pre>
   </div>
@@ -17563,7 +15186,6 @@ _:b0 a as:Connection ;
                 <li><a href="#ex22c-jsonld" class="selected">JSON-LD</a></li>
                 <li><a href="#ex22c-microdata" class="selected">Microdata</a></li>
                 <li><a href="#ex22c-rdfa" class="selected">RDFa</a></li>
-                <li><a href="#ex22c-microformats" class="selected">Microformats</a></li>
                 <li><a href="#ex22c-turtle" class="selected">Turtle</a></li>
               </ul>
               <div id="ex22c-jsonld" style="display: block;">
@@ -17612,18 +15234,6 @@ _:b0 a as:Connection ;
   &lt;/span>
   &lt;span property="b" typeof="Person">
     &lt;span property="displayName">John&lt;/span>
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex22c-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-connection">
-  &lt;span class="h-card">
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/span>
-  knows
-  &lt;span class="h-card">
-    &lt;span class="p-name">John&lt;/span>
   &lt;/span>
 &lt;/div></pre>
   </div>
@@ -17681,7 +15291,7 @@ _:b0 a as:Connection ;
                 <li><a href="#ex185-jsonld" class="selected">JSON-LD</a></li>
                 <li><a href="#ex185-microdata" class="selected">Microdata</a></li>
                 <li><a href="#ex185-rdfa" class="selected">RDFa</a></li>
-                <li><a href="#ex185-microformats" class="selected">Microformats</a></li>
+
                 <li><a href="#ex185-turtle" class="selected">Turtle</a></li>
               </ul>
               <div id="ex185-jsonld" style="display: block;">
@@ -17715,13 +15325,6 @@ _:b0 a as:Connection ;
     &lt;span property="displayName">Sally&lt;/span>
   &lt;/span> -
   &lt;a property="url" href="http://sally.example.org">Profile&lt;/a>
-&lt;/div></pre>
-  </div>
-  <div id="ex185-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-card">
-  &lt;span>Sally&lt;/span> -
-  &lt;a href="http://sally.example.org">Profile&lt;/a>
 &lt;/div></pre>
   </div>
 <div id="ex185-turtle" style="display: none;">

--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -267,7 +267,6 @@
     <li><a href="#ex1-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex1-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex1-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex1-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex1-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex1-jsonld" style="display: block;">
@@ -299,14 +298,6 @@
   &lt;/a>
 &lt;/div></pre>
   </div>
-  <div id="ex1-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;a class="p-author h-card" href="http://martin.example.org/">Martin&lt;/a>
-  posted
-  &lt;img class="u-photo" href="http://martin.example.org/foo.jpg" alt="Photograph of foo"/>
-&lt;/div></pre>
-  </div>
   <div id="ex1-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -336,7 +327,6 @@ _:b0 a as:Post ;
     <li><a href="#ex2-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex2-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex2-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex2-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex2-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex2-jsonld" style="display: block;">
@@ -432,23 +422,6 @@ _:b0 a as:Post ;
   &lt;/meta>
 &lt;/div></pre>
   </div>
-  <div id="ex2-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;a class="p-author h-card" href="http://martin.example.org/">
-    &lt;img src="http://martin.example.org/image.jpg" alt=""
-      />Martin Smith
-  &lt;/a>
-  Posted
-  &lt;a class="u-url p-name" href="http://martin.example.org/blog/2011/02/entry">
-    Why I love Activity Streams
-  &lt;/a>
-  On
-  &lt;time class="dt-published" datetime="2015-02-10 15:04:55Z">
-    February 10, 2015 at 15:04:55 UTC
-  &lt;/time>
-&lt;/div></pre>
-  </div>
   <div id="ex2-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -495,7 +468,6 @@ _:b0 a as:Post ;
     <li><a href="#ex3-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex3-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex3-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex3-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex3-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex3-jsonld" style="display: block;">
@@ -671,56 +643,6 @@ _:b0 a as:Post ;
   &lt;/div>
 &lt;/div></pre>
   </div>
-  <div id="ex3-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems" content="1" />
-  &lt;div class="p-as-items h-as-post">
-    &lt;meta class="dt-published" name="published" content="2011-02-10T15:04:55Z" />
-    &lt;link class="u-as-generator" href="http://example.org/activities-app" />
-    &lt;div class="p-name" lang="en">
-      Martin posted a new video to his album.
-    &lt;/div>
-    &lt;div class="p-name" lang="ga">
-      Martin posted a new video to his album.
-    &lt;/div>
-    &lt;div class="p-author h-card">
-      &lt;meta class="p-as-id" name="id" content="urn:example:person:martin" />
-      &lt;div class="p-name">
-        &lt;a class="u-url" href="http://example.org/martin">Martin Smith&lt;/a>
-      &lt;/div>
-      &lt;img class="u-photo"
-        src="http://example.org/martin/image"
-        type="image/jpeg"
-        height="250" width="250" />
-    &lt;/div>
-    &lt;div class="p-item h-entry">
-      &lt;meta class="p-as-id" name="id" content="http://example.org/album/my_fluffy_cat" />
-      &lt;img class="u-preview"
-        src="http://example.org/album/my_fluffy_cat_thumb.jpg"
-        type="image/jpeg" />
-      &lt;a class="u-url"
-        href="http://example.org/album/my_fluffy_cat.jpg"
-        type="image/jpeg">JPG&lt;/a> |
-      &lt;a class="u-url" typeof="Link"
-        href="http://example.org/album/my_fluffy_cat.png"
-        type="image/png">PNG&lt;/a>
-    &lt;/div>
-    &lt;div class="p-as-target h-entry"
-      &lt;meta class="p-as-id" name="id" content="http://example.org/album/" />
-      &lt;div class="p-name" lang="en">
-        Martin's Photo Album
-      &lt;/div>
-      &lt;div class="p-name" lang="ga">
-        Grianghraif Mairtin
-      &lt;/div>
-      &lt;img class="u-photo"
-        href="http://example.org/album/thumbnail.jpg"
-        type="image/jpeg" />
-    &lt;/div>
-  &lt;/div>
-&lt;/div></pre>
-  </div>
   <div id="ex3-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -870,7 +792,6 @@ keywords to express the global identifier and object type:</figcaption>
     <li><a href="#ex4-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex4-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex4-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex4-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex4-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex4-jsonld" style="display: block;">
@@ -910,17 +831,6 @@ keywords to express the global identifier and object type:</figcaption>
   &lt;/div>
   &lt;div property="published">2014-08-21T12:34:56Z&lt;/div>
 &lt;/div></pre></div>
-  <div id="ex4-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;meta class="p-as-id" name="id" content="http://example.org/foo" />
-  &lt;div class="p-name">This is a note&lt;/div>
-  &lt;div class="p-author h-card">
-    &lt;meta class="p-as-id" name="id" content="urn:example:person:joe" />
-    &lt;span class="p-name">Joe Smith&lt;/span>
-  &lt;/div>
-  &lt;div class="dt-published">2014-08-21T12:34:56Z&lt;/div>
-&lt;/div></pre></div>
   <div id="ex4-turtle" style="display: none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -950,7 +860,6 @@ value of <code>object</code> is not:</figcaption>
     <li><a href="#ex5-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex5-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex5-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex5-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex5-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex5-jsonld" style="display: block;">
@@ -996,20 +905,6 @@ value of <code>object</code> is not:</figcaption>
     &lt;span property="displayName">Sally&lt;/span>
   &lt;/div>
   &lt;a property="object" itemscope typeof="Link"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-&lt;/div></pre></div>
-  <div id="ex5-microformats" style="display: none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;meta class="p-as-id" name="id" content="http://example.org/foo" />
-  &lt;div class="p-name">A Test&lt;/div>
-  &lt;div class="p-author h-card"
-    &lt;meta class="p-as-id" name="id" content="http://example.org/~sally" />
-    &lt;span class="p-name">Sally&lt;/span>
-  &lt;/div>
-  &lt;a class="u-share-of"
     href="http://example.org/posts/1">
     http://example.org/posts/1
   &lt;/a>
@@ -1063,7 +958,6 @@ value of <code>object</code> is not:</figcaption>
     <li><a href="#ex6-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex6-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex6-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex6-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex6-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex6-jsonld" style="display: block;">
@@ -1103,15 +997,6 @@ value of <code>object</code> is not:</figcaption>
   Latitude: &lt;span property="latitude">56.78&lt;/span>.
   &lt;meta property="http://purl.org/goodrelations/v1#category"
     content="restaurants/french_restaurants" />
-&lt;/div></pre></div>
-  <div id="ex6-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-geo">
-  &lt;div class="p-name">Sally's Restaurant&lt;/div>
-  At
-  Longitude: &lt;span class="p-longitude">12.34&lt;/span>,
-  Latitude: &lt;span class="p-latitude">56.78&lt;/span>.
-  &lt;meta name="category" content="restaurants/french_restaurants" />
 &lt;/div></pre></div>
   <div id="ex6-turtle" style="display:none;">
 <pre class="example highlight turtle"
@@ -1164,7 +1049,6 @@ _:b0 a as:Place, gr:Location ;
     <li><a href="#ex7-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex7-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex7-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex7-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex7-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex7-jsonld" style="display: block;">
@@ -1184,11 +1068,6 @@ _:b0 a as:Place, gr:Location ;
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Object">
   &lt;div property="displayName">This is the title&lt;/div>
 &lt;/div></pre></div>
-  <div id="ex7-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;div class="p-name">This is the title&lt;/div>
-&lt;/div></pre></div>
   <div id="ex7-turtle" style="display:none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -1205,7 +1084,6 @@ _:b0 a as:Object ;
     <li><a href="#ex8-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex8-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex8-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex8-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex8-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex8-jsonld" style="display: block;">
@@ -1232,13 +1110,6 @@ _:b0 a as:Object ;
   &lt;div property="displayName" lang="en">This is the title&lt;/div>
   &lt;div property="displayName" lang="fr">C'est le titre&lt;/div>
   &lt;div property="displayName" lang="sp">Este es el titulo&lt;/div>
-&lt;/div></pre></div>
-  <div id="ex8-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;div class="p-name" lang="en">This is the title&lt;/div>
-  &lt;div class="p-name" lang="fr">C'est le titre&lt;/div>
-  &lt;div class="p-name" lang="sp">Este es el titulo&lt;/div>
 &lt;/div></pre></div>
   <div id="ex8-turtle" style="display:none;">
 <pre class="example highlight turtle"
@@ -1287,7 +1158,6 @@ _:b0 a as:Object ;
     <li><a href="#ex9-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex9-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex9-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex9-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex9-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex9-jsonld" style="display: block;">
@@ -1309,11 +1179,6 @@ _:b0 a as:Object ;
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Object" lang="en">
   &lt;div property="displayName">This is the title&lt;/div>
-&lt;/div></pre></div>
-  <div id="ex9-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry" lang="en">
-  &lt;div class="p-name">This is the title&lt;/div>
 &lt;/div></pre></div>
   <div id="ex9-turtle" style="display:none;">
 <pre class="example highlight turtle"
@@ -1337,7 +1202,6 @@ _:b0 a as:Object ;
     <li><a href="#ex10-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex10-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex10-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex10-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex10-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex10-jsonld" style="display: block;">
@@ -1359,11 +1223,6 @@ _:b0 a as:Object ;
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Object">
   &lt;div property="displayName" lang="en">This is the title&lt;/div>
-&lt;/div></pre></div>
-  <div id="ex10-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry">
-  &lt;div class="p-name" lang="en">This is the title&lt;/div>
 &lt;/div></pre></div>
   <div id="ex10-turtle" style="display:none;">
 <pre class="example highlight turtle"
@@ -1391,7 +1250,6 @@ _:b0 a as:Object ;
     <li><a href="#ex11-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex11-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex11-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex11-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex11-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex11-jsonld" style="display: block;">
@@ -1415,11 +1273,6 @@ _:b0 a as:Object ;
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Object" lang="en">
   &lt;div property="displayName" lang="">This is the title&lt;/div>
-&lt;/div></pre></div>
-  <div id="ex11-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry" lang="en">
-  &lt;div class="p-name" lang="">This is the title&lt;/div>
 &lt;/div></pre></div>
   <div id="ex11-turtle" style="display:none;">
 <pre class="example highlight turtle"
@@ -1486,7 +1339,6 @@ _:b0 a as:Object ;
     <li><a href="#ex12-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex12-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex12-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex12-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex12-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex12-jsonld" style="display: block;">
@@ -1514,14 +1366,6 @@ _:b0 a as:Object ;
   &lt;img property="image"
        src="http://example.org/application/123.png" />
 &lt;/div></pre></div>
-  <div id="ex12-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry"
-  &lt;meta class="p-as-id" name="id" content="http://example.org/application/123">
-  &lt;div class="p-name">My Application&lt;/div>
-  &lt;img class="u-photo"
-       src="http://example.org/application/123.png" />
-&lt;/div></pre></div>
   <div id="ex12-turtle" style="display:none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -1541,7 +1385,6 @@ _:b0 a as:Object ;
     <li><a href="#ex13-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex13-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex13-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex13-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex13-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex13-jsonld" style="display: block;">
@@ -1575,14 +1418,6 @@ _:b0 a as:Object ;
   &lt;img property="image" typeof="Link"
     type="image/png"
     src="http://example.org/application/123.png" />
-&lt;/div></pre></div>
-  <div id="ex13-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry"
-  &lt;meta class="p-as-id" name="id" content="http://example.org/application/123">
-  &lt;div class="p-name">My Application&lt;/div>
-  &lt;img class="u-photo"
-       src="http://example.org/application/123.png" />
 &lt;/div></pre></div>
   <div id="ex13-turtle" style="display:none;">
 <pre class="example highlight turtle"
@@ -1619,7 +1454,6 @@ _:b0 a as:Object ;
     <li><a href="#ex14-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex14-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex14-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex14-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex14-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex14-jsonld" style="display: block;">
@@ -1659,16 +1493,6 @@ _:b0 a as:Object ;
     src="http://example.org/application/123.gif" />
   &lt;img property="image" typeof="Link"
     type="image/png"
-    src="http://example.org/application/123.png" />
-&lt;/div></pre></div>
-  <div id="ex14-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-application"
-  &lt;meta class="p-as-id" name="id" content="http://example.org/application/123">
-  &lt;div class="p-name">My Application&lt;/div>
-  &lt;img class="u-photo"
-    src="http://example.org/application/123.gif" />
-  &lt;img class="u-photo"
     src="http://example.org/application/123.png" />
 &lt;/div></pre></div>
   <div id="ex14-turtle" style="display:none;">
@@ -1717,7 +1541,6 @@ _:b0 a as:Object ;
     <li><a href="#ex15-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex15-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex15-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex15-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex15-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex15-jsonld" style="display: block;">
@@ -1761,17 +1584,6 @@ _:b0 a as:Object ;
     type="image/png"
     src="http://example.org/application/123.png"
     rel="thumbnail" />
-&lt;/div></pre></div>
-  <div id="ex15-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-application"
-  &lt;meta class="p-as-id" name="id" content="http://example.org/application/123">
-  &lt;div class="p-name">My Application&lt;/div>
-  &lt;img class="u-photo"
-    src="http://example.org/application/123.gif" />
-  &lt;img class="u-photo"
-       src="http://example.org/application/123.png"
-       rel="thumbnail" />
 &lt;/div></pre></div>
   <div id="ex15-turtle" style="display:none;">
 <pre class="example highlight turtle"
@@ -1844,7 +1656,6 @@ _:b0 a as:Object ;
     <li><a href="#ex16-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex16-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex16-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex16-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex16-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex16-jsonld" style="display: block;">
@@ -1888,19 +1699,6 @@ _:b0 a as:Object ;
     "&lt;span property="content">This is a simple note&lt;/span>"
   &lt;/div>
 &lt;/div></pre></div>
-  <div id="ex16-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;div class="p-author h-card">
-    &lt;link class="u-url p-name" href="acct:sally@example.org">
-      Sally Smith
-    &lt;/link>
-  &lt;/div>
-  Shared
-  &lt;div class="p-share-of h-entry">
-    "&lt;span class="e-content">This is a simple note&lt;/span>"
-  &lt;/div>
-&lt;/div></pre></div>
   <div id="ex16-turtle" style="display:none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -1922,7 +1720,6 @@ _:b0 a as:Share ;
     <li><a href="#ex17-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex17-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex17-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex17-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex17-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex17-jsonld" style="display: block;">
@@ -1975,20 +1772,6 @@ _:b0 a as:Share ;
     "&lt;span property="content">This is a simple note&lt;/span>"
   &lt;/div>
 &lt;/div></pre></div>
-  <div id="ex17-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;div class="p-author h-card">
-    &lt;link class="u-url p-name" href="acct:sally@example.org">
-      &lt;span class="p-given-name">Sally&lt;/span>
-      &lt;span class="p-family-name">Smith&lt;/span>
-    &lt;/link>
-  &lt;/div>
-  Shared
-  &lt;div class="p-share-of h-entry">
-    "&lt;span class="e-content">This is a simple note&lt;/span>"
-  &lt;/div>
-&lt;/div></pre></div>
   <div id="ex17-turtle" style="display:none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -2028,7 +1811,6 @@ _:c14n0 a as:Share ;
     <li><a href="#ex18-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex18-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex18-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex18-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex18-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex18-jsonld" style="display: block;">
@@ -2082,20 +1864,6 @@ _:c14n0 a as:Share ;
   Shared
   &lt;div property="object" typeof="Note">
     "&lt;span property="content">This is a simple note&lt;/span>"
-  &lt;/div>
-&lt;/div></pre></div>
-  <div id="ex18-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-share">
-  &lt;div class="p-author h-card">
-    &lt;link class="u-url p-name" href="acct:sally@example.org">
-      &lt;span class="p-given-name">Sally&lt;/span>
-      &lt;span class="p-family-name">Smith&lt;/span>
-    &lt;/link>
-  &lt;/div>
-  Shared
-  &lt;div class="p-share-of h-entry">
-    "&lt;span class="e-content">This is a simple note&lt;/span>"
   &lt;/div>
 &lt;/div></pre></div>
   <div id="ex18-turtle" style="display:none;">
@@ -2157,7 +1925,6 @@ _:b0 a as:Share ;
     <li><a href="#ex19-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex19-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex19-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex19-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex19-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex19-jsonld" style="display: block;">
@@ -2190,17 +1957,6 @@ _:b0 a as:Share ;
     "http://example.org/notes/1"
   &lt;/a>
   &lt;meta property="published" content="2014-09-30T12:34:56Z" />
-&lt;/div></pre></div>
-  <div id="ex19-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-like">
-  &lt;a class="u-author" href="http://example.org/profiles/joe">Joe&lt;/a>
-  liked
-  &lt;a class="u-like-of" href="http://example.org/notes/1">
-    "http://example.org/notes/1"
-  &lt;/a>
-  &lt;meta class="dt-published" name="published"
-    content="2014-09-30T12:34:56Z" />
 &lt;/div></pre></div>
   <div id="ex19-turtle" style="display:none;">
 <pre class="example highlight turtle"
@@ -2246,7 +2002,6 @@ _:b0 a as:Share ;
     <li><a href="#ex20-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex20-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex20-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex20-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex20-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex20-jsonld" style="display: block;">
@@ -2279,17 +2034,6 @@ _:b0 a as:Share ;
     "http://example.org/notes/1"
   &lt;/a>
   &lt;meta property="published" content="2014-09-30T12:34:56Z" />
-&lt;/div></pre></div>
-  <div id="ex20-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-like">
-  &lt;a class="u-author" href="http://example.org/profiles/joe">Joe&lt;/a>
-  liked
-  &lt;a class="u-like-of" href="http://example.org/notes/1">
-    "http://example.org/notes/1"
-  &lt;/a>
-  &lt;meta class="dt-published" name="published"
-    content="2014-09-30T12:34:56Z" />
 &lt;/div></pre></div>
   <div id="ex20-turtle" style="display:none;">
 <pre class="example highlight turtle"
@@ -2462,7 +2206,6 @@ _:b0 a as:Share ;
     <li><a href="#ex21-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex21-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex21-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex21-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex21-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex21-jsonld" style="display: block;">
@@ -2512,21 +2255,6 @@ _:b0 a as:Share ;
     &lt;/li&lt;
   &lt;ul>
 &lt;/div></pre></div>
-  <div id="ex21-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems" content="10" />
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage" content="1" />
-  &lt;a rel="next" href="http://example.org/foo?page=2">Next Page&lt;/a>
-  &lt;link rel="self" href="http://example.org/foo?page=1" />
-  &lt;ul class="p-as-items">
-    &lt;li class="h-as-post"&lt;
-      &lt;link class="u-author" href="urn:example:person:sally">Sally&lt;/link>
-      Posted
-      &lt;a class="u-item" href="http://example.org/foo">"http://example.org/foo"&lt;/a>
-    &lt;/li&lt;
-  &lt;ul>
-&lt;/div></pre></div>
   <div id="ex21-turtle" style="display:none;">
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
@@ -2551,7 +2279,6 @@ _:b0 a as:Collection ;
     <li><a href="#ex22-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex22-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex22-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex22-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex22-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex22-jsonld" style="display: block;">
@@ -2603,22 +2330,6 @@ _:b0 a as:Collection ;
       &lt;link property="actor" href="urn:example:person:sally">Sally&lt;/link>
       Posted
       &lt;a property="object" href="http://example.org/foo">"http://example.org/foo"&lt;/a>
-    &lt;/li&lt;
-  &lt;ol>
-&lt;/div></pre></div>
-  <div id="ex22-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-collection">
-  &lt;meta class="p-as-total-items" name="totalItems" content="10" />
-  &lt;meta class="p-as-items-per-page" name="itemsPerPage" content="1" />
-  &lt;meta class="p-as-start-index" name="startIndex" content="0" />
-  &lt;a rel="next" href="http://example.org/foo?page=2">Next Page&lt;/a>
-  &lt;link rel="self" href="http://example.org/foo?page=1" />
-  &lt;ol class="p-as-items">
-    &lt;li class="h-as-post"&lt;
-      &lt;link class="u-author" href="urn:example:person:sally">Sally&lt;/link>
-      Posted
-      &lt;a class="u-item" href="http://example.org/foo">"http://example.org/foo"&lt;/a>
     &lt;/li&lt;
   &lt;ol>
 &lt;/div></pre></div>
@@ -2828,7 +2539,6 @@ _:c14n0 a as:OrderedCollection ;
     <li><a href="#ex23-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex23-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex23-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex23-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex23-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex23-jsonld" style="display: block;">
@@ -2850,12 +2560,6 @@ _:c14n0 a as:OrderedCollection ;
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Place">
   &lt;meta property="latitude" content="36.74" />
   &lt;meta property="longitude" content="-119.77" />
-&lt;/div></pre></div>
-  <div id="ex23-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-geo">
-  &lt;meta class="p-latitude" name="latitude" content="36.74" />
-  &lt;meta class="p-longitude" name="longitude" content="-119.77" />
 &lt;/div></pre></div>
   <div id="ex23-turtle" style="display:none;">
 <pre class="example highlight turtle"
@@ -2888,7 +2592,6 @@ _:c14n0 a as:Place;
     <li><a href="#ex24-jsonld" class="selected">JSON-LD</a></li>
     <li><a href="#ex24-microdata" class="selected">Microdata</a></li>
     <li><a href="#ex24-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex24-microformats" class="selected">Microformats</a></li>
     <li><a href="#ex24-turtle" class="selected">Turtle</a></li>
   </ul>
   <div id="ex24-jsonld" style="display: block;">
@@ -2914,13 +2617,6 @@ _:c14n0 a as:Place;
   typeof="itemtype="http://www.opengis.net/ont/geosparql#Geometry"">
   &lt;meta
     property="http://www.opengis.net/ont/geosparql#asWKT"
-    content="Polygon((100.0, 0.0, 101.0, 0.0, 101.0, 1.0, 100.0, 1.0, 100.0, 0.0))" />
-&lt;/div></pre></div>
-  <div id="ex24-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-geo">
-  &lt;meta
-    name="wkt"
     content="Polygon((100.0, 0.0, 101.0, 0.0, 101.0, 1.0, 100.0, 1.0, 100.0, 0.0))" />
 &lt;/div></pre></div>
   <div id="ex24-turtle" style="display:none;">


### PR DESCRIPTION
rather than publish another WD with incorrect and
non-normative microformats examples, simply remove
them. If we want to define a normative microformats
mapping in a separate document, then we can still do
so. Having incorrect non-normative examples is not
helpful.