### PR TITLE
remove the Post activity

### DIFF
--- a/activitystreams2-context.jsonld
+++ b/activitystreams2-context.jsonld
@@ -45,7 +45,6 @@
     "Page": "as:Page",
     "Person": "as:Person",
     "Place": "as:Place",
-    "Post": "as:Post",
     "Process": "as:Process",
     "Profile": "as:Profile",
     "Question": "as:Question",

--- a/activitystreams2-vocabulary.html
+++ b/activitystreams2-vocabulary.html
@@ -1068,7 +1068,6 @@ _:b0 a as:OrderedCollection ;
         <code><a>Listen</a></code> |
         <code><a>Move</a></code> |
         <code><a>Offer</a></code> |
-        <code><a>Post</a></code> |
         <code><a>Question</a></code> |
         <code><a>Reject</a></code> |
         <code><a>Read</a></code> |
@@ -1793,11 +1792,6 @@ _:b0 a as:Create ;
             <td>
               <p>Indicates that the <code>actor</code> has created the
               <code>object</code>.</p>
-
-              <p><code>Create</code> is generally equivalent to
-              <code><a>Post</a></code> with the exception that the
-              <code><a>Post</a></code> Activity has a defined meaning for
-              "target" while <code>Create</code> does not.</p>
             </td>
           </tr>
           <tr>
@@ -2819,108 +2813,6 @@ _:b0 a as:Invite ;
           <tr>
             <td>Properties:</td>
             <td>Inherits all properties from <code><a>Offer</a></code>.
-          </tr>
-        </tbody>
-        <tbody>
-          <tr>
-            <td rowspan="4" ><dfn>Post</dfn></td>
-            <td  style="width: 10%">URI:</td>
-            <td><code>http://www.w3.org/ns/activitystreams#Post</code></td>
-            <td rowspan="4" >
-<div class="nanotabs">
-  <ul>
-    <li><a href="#ex25-jsonld" class="selected">JSON-LD</a></li>
-    <li><a href="#ex25-microdata" class="selected">Microdata</a></li>
-    <li><a href="#ex25-rdfa" class="selected">RDFa</a></li>
-
-    <li><a href="#ex25-turtle" class="selected">Turtle</a></li>
-  </ul>
-  <div id="ex25-jsonld" style="display: block;">
-<pre class="example highlight json">{
-  "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Post",
-  "actor": {
-    "@type": "Person",
-    "displayName": "Sally"
-  },
-  "object": {
-    "@type": "Note",
-    "displayName": "A Simple Note",
-    "content": "This is a simple note"
-  }
-}</pre>
-</div>
-<div id="ex25-microdata" style="display:none;">
-<pre class="example highlight html"
->&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Post">
-  &lt;span itemprop="actor" itemscope
-    itemtype="http://www.w3.org/ns/activitystreams#Person">
-    &lt;span itemprop="displayName">Sally&lt;/span>
-  &lt;/span>
-  published
-  &lt;span itemprop="object" itemscope
-    itemtype="http://www.w3.org/ns/activitystreams#Note">
-    a note titled
-    "&lt;span itemprop="displayName">A Simple Note&lt;/span>"
-    with content
-    "&lt;span itemprop="content">This is a simple note&lt;/span>"
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-  <div id="ex25-rdfa" style="display:none;">
-<pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Post">
-  &lt;span property="actor" typeof="Person">
-    &lt;span property="displayName">Sally&lt;/span>
-  &lt;/span>
-  published
-  &lt;span property="object" typeof="Note">
-    a note titled
-    "&lt;span property="displayName">A Simple Note&lt;/span>"
-    with content
-    "&lt;span property="content">This is a simple note&lt;/span>"
-  &lt;/span>
-&lt;/div></pre>
-  </div>
-<div id="ex25-turtle" style="display: none;">
-<pre class="example highlight turtle">
-@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
-
-_:b0 a as:Post ;
-  as:actor [
-    a as:Person ;
-      as:displayName "Sally" .
-  ] ;
-  as:object [
-    a as:Note ;
-      as:displayName "A Simple Note" ;
-      as:content "This is a simple note" .
-  ] .</pre>
-  </div>
-</div>
-            </td>
-          </tr>
-          <tr>
-            <td>Notes:</td>
-            <td>
-              <p>Indicates that the <code>actor</code> is posting the
-              <code>object</code>. If specified, the <code>target</code>
-              indicates to entity to which the <code>object</code> is being
-              posted.</p>
-
-              <p>Implementations can treat <code><a>Post</a></code> as being
-              generally equivalent to <code><a>Create</a></code></p>.
-            </td>
-          </tr>
-          <tr>
-            <td>Extends:</td>
-            <td><code><a>Activity</a></code></td>
-          </tr>
-          <tr>
-            <td>Properties:</td>
-            <td>Inherits all properties from <code><a>Activity</a></code>.</td>
           </tr>
         </tbody>
 

--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -259,7 +259,7 @@
 
   <figure>
   <figcaption>
-    Expresses the statement <code>'urn:example:person:martin' posted
+    Expresses the statement <code>'urn:example:person:martin' created
     'http://example.org/foo.jpg'</code>.  No additional detail is given.
   </figcaption>
 <div class="nanotabs">
@@ -272,7 +272,7 @@
   <div id="ex1-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Post",
+  "@type": "Create",
   "actor": "urn:example:person:martin",
   "object": "http://example.org/foo.jpg"
 }</pre>
@@ -280,9 +280,9 @@
   <div id="ex1-microdata" style="display: none;">
 <pre class="example highlight html"
 >&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Post">
+  itemtype="http://www.w3.org/ns/activitystreams#Create">
   &lt;link itemprop="actor" href="urn:example:person:martin">Martin&lt;/link>
-  posted
+  created
   &lt;a itemprop="object" href="http://example.org/foo.jpg">
     "http://example.org/foo.jpg"
   &lt;/a>
@@ -290,9 +290,9 @@
   </div>
   <div id="ex1-rdfa" style="display: none;">
 <pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Post">
+>&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Create">
   &lt;link property="actor" href="urn:example:person:martin">Martin&lt;/link>
-  posted
+  created
   &lt;a property="object" href="http://example.org/foo.jpg">
     "http://example.org/foo.jpg"
   &lt;/a>
@@ -302,7 +302,7 @@
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 
-_:b0 a as:Post ;
+_:b0 a as:Create ;
   as:actor &lt;urn:example:person:martin&gt; ;
   as:object &lt;http://example.org/foo.jpg&gt; .</pre>
   </div>
@@ -315,7 +315,7 @@ _:b0 a as:Post ;
 
       <figure>
       <figcaption>
-        Expresses the statement "Martin Smith posted an article to the blog
+        Expresses the statement "Martin Smith added an article to the blog
         'Martin's Blog' at 3:04 PM UTC on February 2, 2015."  Some additional
         details about the article, actor and target blog are given using
         properties defined by the
@@ -332,7 +332,7 @@ _:b0 a as:Post ;
   <div id="ex2-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Post",
+  "@type": "Add",
   "published": "2015-02-10T15:04:55Z",
   "actor": {
    "@type": "Person",
@@ -360,7 +360,7 @@ _:b0 a as:Post ;
   </div>
   <div id="ex2-microdata" style="display: none;">
 <pre class="example highlight html"
->&lt;div itemscope itemtype="http://www.w3.org/ns/activitystreams#Post">
+>&lt;div itemscope itemtype="http://www.w3.org/ns/activitystreams#Add">
   &lt;div itemprop="actor" itemscope
     itemtype="http://www.w3.org/ns/activitystreams#Person"
     itemid="urn:example:person:martin">
@@ -372,7 +372,7 @@ _:b0 a as:Post ;
       src="http://example.org/martin/image.jpg"
       type="image/jpeg" />
   &lt;/div>
-  Posted
+  created
   &lt;div itemprop="object" itemscope
     itemtype="http://www.w3.org/ns/activitystreams#Article"
     itemid="urn:example:blog:abc123/xyz">
@@ -394,7 +394,7 @@ _:b0 a as:Post ;
   </div>
   <div id="ex2-rdfa" style="display: none;">
 <pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Post">
+>&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Add">
   &lt;div property="actor" typeof="Person"
     resource="urn:example:person:martin">
     &lt;a property="url" href="http://example.org/martin">
@@ -404,7 +404,7 @@ _:b0 a as:Post ;
       src="http://example.org/martin/image.jpg"
       type="image/jpeg" />
   &lt;/div>
-  Posted
+  created
   &lt;div property="object" typeof="Article"
     resource="urn:example:blog:abc123/xyz">
     &lt;a property="url" href="http://example.org/blog/2011/02/entry">
@@ -443,7 +443,7 @@ _:b0 a as:Post ;
   as:displayName "Why I love Activity Streams" ;
   as:url &lt;http://example.org/blog/2011/02/entry&gt; .
 
-_:b0 a as:Post ;
+_:b0 a as:Add ;
   as:published "2015-02-10T15:04:55Z"^^xsd:dateTime ;
   as:actor &lt;urn:example:person:martin&gt; ;
   as:object &lt;urn:example:blog:abc123/xyz&gt; ;
@@ -477,11 +477,11 @@ _:b0 a as:Post ;
   "totalItems": 1,
   "items" : [
     {
-      "@type": "Post",
+      "@type": "Add",
       "published": "2011-02-10T15:04:55Z",
       "generator": "http://example.org/activities-app",
       "displayNameMap": {
-        "en": "Martin posted a new video to his album.",
+        "en": "Martin added a new video to his album.",
         "ga": "Martin phost le fisean nua a albam."
       },
       "actor": {
@@ -539,14 +539,14 @@ _:b0 a as:Post ;
 <pre class="example highlight html"
 >&lt;div itemscope itemtype="http://www.w3.org/ns/activitystreams#Collection">
   &lt;meta itemprop="totalItems" content="1" />
-  &lt;div itemprop="items" itemscope itemtype="http://www.w3.org/ns/activitystreams#Post">
+  &lt;div itemprop="items" itemscope itemtype="http://www.w3.org/ns/activitystreams#Add">
     &lt;meta itemprop="published" content="2011-02-10T15:04:55Z" />
     &lt;link itemprop="generator" href="http://example.org/activities-app" />
     &lt;div itemprop="displayName" lang="en">
-      Martin posted a new video to his album.
+      Martin added a new video to his album.
     &lt;/div>
     &lt;div itemprop="displayName" lang="ga">
-      Martin posted a new video to his album.
+      Martin added a new video to his album.
     &lt;/div>
     &lt;div itemprop="actor" itemscope
       itemtype="http://www.w3.org/ns/activitystreams#Person"
@@ -596,14 +596,14 @@ _:b0 a as:Post ;
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Collection">
   &lt;meta property="totalItems" content="1" />
-  &lt;div property="items"  typeof="Post">
+  &lt;div property="items"  typeof="Add">
     &lt;meta property="published" content="2011-02-10T15:04:55Z" />
     &lt;link property="generator" href="http://example.org/activities-app" />
     &lt;div property="displayName" lang="en">
-      Martin posted a new video to his album.
+      Martin added a new video to his album.
     &lt;/div>
     &lt;div property="displayName" lang="ga">
-      Martin posted a new video to his album.
+      Martin added a new video to his album.
     &lt;/div>
     &lt;div property="actor" typeof="Person"
       resource="urn:example:person:martin">
@@ -688,10 +688,10 @@ _:b0 a as:Post ;
 _:b0 a as:Collection ;
   as:totalItems "1"^^xsd:nonNegativeInteger ;
   as:items [
-    a as:Post ;
+    a as:Add ;
       as:published "2011-02-10T15:04:55Z"^^xsd:dateTime ;
       as:generator &lt;http://example.org/activities-app&gt; ;
-      as:displayName "Martin posted a new video to his album."@en ;
+      as:displayName "Martin added a new video to his album."@en ;
       as:displayName "Martin phost le fisean nua a albam."@ga ;
       as:actor &lt;urn:example:person:martin&gt; ;
       as:object &lt;http://example.org/album/my_fluffy_cat&gt; ;
@@ -2218,7 +2218,7 @@ _:b0 a as:Share ;
   "self": "http://example.org/foo?page=1",
   "items": [
     {
-      "@type": "Post",
+      "@type": "Create",
       "actor": "urn:example:person:sally",
       "object": "http://example.org/foo"
     }
@@ -2233,9 +2233,9 @@ _:b0 a as:Share ;
   &lt;a itemprop="next" href="http://example.org/foo?page=2">Next Page&lt;/a>
   &lt;link itemprop="self" href="http://example.org/foo?page=1" />
   &lt;ul>
-    &lt;li itemscope itemtype="http://www.w3.org/ns/activitystreams#Post"&lt;
+    &lt;li itemscope itemtype="http://www.w3.org/ns/activitystreams#Create"&lt;
       &lt;link itemprop="actor" href="urn:example:person:sally">Sally&lt;/link>
-      Posted
+      created
       &lt;a itemprop="object" href="http://example.org/foo">"http://example.org/foo"&lt;/a>
     &lt;/li&lt;
   &lt;ul>
@@ -2248,9 +2248,9 @@ _:b0 a as:Share ;
   &lt;a property="next" href="http://example.org/foo?page=2">Next Page&lt;/a>
   &lt;link property="self" href="http://example.org/foo?page=1" />
   &lt;ul>
-    &lt;li property typeof="Post"&lt;
+    &lt;li property typeof="Create"&lt;
       &lt;link property="actor" href="urn:example:person:sally">Sally&lt;/link>
-      Posted
+      created
       &lt;a property="object" href="http://example.org/foo">"http://example.org/foo"&lt;/a>
     &lt;/li&lt;
   &lt;ul>
@@ -2266,7 +2266,7 @@ _:b0 a as:Collection ;
   as:next &lt;http://example.org/foo?page=2&gt; ;
   as:self &lt;http://example.org/foo?page=1&gt; ;
   as:items [
-      a as:Post;
+      a as:Create;
         as:actor &lt;urn:example:person:sally&gt; ;
         as:object &lt;http://example.org/foo&gt;
   ] .</pre></div>
@@ -2293,7 +2293,7 @@ _:b0 a as:Collection ;
   "startIndex": 0,
   "orderedItems": [
     {
-      "@type": "Post",
+      "@type": "Create",
       "actor": "urn:example:person:sally",
       "object": "http://example.org/foo"
     }
@@ -2310,9 +2310,9 @@ _:b0 a as:Collection ;
   &lt;a itemprop="next" href="http://example.org/foo?page=2">Next Page&lt;/a>
   &lt;link itemprop="self" href="http://example.org/foo?page=1" />
   &lt;ol>
-    &lt;li itemscope itemtype="http://www.w3.org/ns/activitystreams#Post"&lt;
+    &lt;li itemscope itemtype="http://www.w3.org/ns/activitystreams#Create"&lt;
       &lt;link itemprop="actor" href="urn:example:person:sally">Sally&lt;/link>
-      Posted
+      created
       &lt;a itemprop="object" href="http://example.org/foo">"http://example.org/foo"&lt;/a>
     &lt;/li&lt;
   &lt;ol>
@@ -2326,9 +2326,9 @@ _:b0 a as:Collection ;
   &lt;a property="next" href="http://example.org/foo?page=2">Next Page&lt;/a>
   &lt;link property="self" href="http://example.org/foo?page=1" />
   &lt;ol>
-    &lt;li property typeof="Post"&lt;
+    &lt;li property typeof="Create"&lt;
       &lt;link property="actor" href="urn:example:person:sally">Sally&lt;/link>
-      Posted
+      created
       &lt;a property="object" href="http://example.org/foo">"http://example.org/foo"&lt;/a>
     &lt;/li&lt;
   &lt;ol>
@@ -2347,7 +2347,7 @@ _:c14n0 a as:OrderedCollection ;
   as:self &lt;http://example.org/foo?page=1&gt; ;
   as:items [
     rdf:first [
-      a as:Post;
+      a as:Create;
         as:actor &lt;urn:example:person:sally&gt; ;
         as:object &lt;http://example.org/foo&gt;
     ] ;
@@ -2475,6 +2475,22 @@ _:c14n0 a as:OrderedCollection ;
       reasonable implementation evidence. While the
       <code>upstreamDuplicates</code> and <code>downstreamDuplicates</code>
       properties MAY continue to be used, implementations SHOULD avoid them.
+    </li>
+    <li>
+      In Activity Streams 1.0, the "<code>post</code>" verb was defined to
+      describe the action of both creating an object and "posting" or uploading
+      it to a service. This specification replaces the "<code>post</code>" verb
+      with separate
+      <code><a href="activitystreams2-vocabulary.html#dfn-create">Create</a></code> and
+      <code><a href="activitystreams2-vocabulary.html#dfn-add">Add</a></code>
+      Activity types. When processing Activity Streams 1.0 documents and
+      converting those into 2.0, implementations SHOULD treat instances of the
+      "<code>post</code>" verb as equivalent to
+      <code><a href="activitystreams2-vocabulary.html#dfn-create">Create</a></code>
+      <i>if there is no <code>target</code> property specified</i>; and
+      equivalent to
+      <code><a href="activitystreams2-vocabulary.html#dfn-add">Add</a></code>
+      <i>if there is a <code>target</code> property specified</i>.
     </li>
     </ol>
 
@@ -2894,7 +2910,7 @@ _:c14n0 a gsp:Geometry ;
       replaced with a hyperlink to a listing of other notes that have been
       "tagged" with the same topic. Most implementations would also send a
       special notification to sally letting her know that a note mentioning her
-      has been posted.
+      has been created.
     </p>
 
     <p>

--- a/activitystreams2.owl
+++ b/activitystreams2.owl
@@ -773,7 +773,6 @@ as:Content a owl:Class ;
 as:Create a owl:Class ;
   rdfs:label "Create"@en ;
   rdfs:subClassOf as:Activity ;
-  owl:equivalentClass as:Post ;
   rdfs:comment "To Create Something"@en .
 
 as:Delete a owl:Class ;
@@ -984,11 +983,6 @@ as:Place a owl:Class ;
   rdfs:label "Place"@en ;
   rdfs:subClassOf as:Object ;
   rdfs:comment "A physical or logical location"@en .
-
-as:Post a owl:Class ;
-  rdfs:label "Post"@en ;
-  rdfs:subClassOf as:Activity ;
-  rdfs:comment "To Post/Create Something"@en .
 
 as:Process a owl:Class ;
   rdfs:label "Process"@en ;


### PR DESCRIPTION
To reduce confusion, remove the "Post" activity and clearly
indicate that "Create" and "Add" replace the original function
of the AS1 "post" verb. Provide clear deprecation and handling
advice.