### PR TITLE
remove "Share"

### DIFF
--- a/activitystreams2-context.jsonld
+++ b/activitystreams2-context.jsonld
@@ -52,7 +52,6 @@
     "Review": "as:Review",
     "Save": "as:Save",
     "Service": "as:Service",
-    "Share": "as:Share",
     "Story": "as:Story",
     "TentativeAccept": "as:TentativeAccept",
     "TentativeReject": "as:TentativeReject",

--- a/activitystreams2-vocabulary.html
+++ b/activitystreams2-vocabulary.html
@@ -1074,7 +1074,6 @@ _:b0 a as:OrderedCollection ;
         <code><a>Respond</a></code> |
         <code><a>Review</a></code> |
         <code><a>Save</a></code> |
-        <code><a>Share</a></code> |
         <code><a>TentativeReject</a></code> |
         <code><a>TentativeAccept</a></code> |
         <code><a>Travel</a></code> |
@@ -3463,101 +3462,7 @@ _:b0 a as:Save ;
             <td>Inherits all properties from <code><a>Activity</a></code>.</td>
           </tr>
         </tbody>
-        <tbody>
-          <tr>
-            <td rowspan="4" ><dfn>Share</dfn></td>
-            <td  style="width: 10%">URI:</td>
-            <td><code>http://www.w3.org/ns/activitystreams#Share</code></td>
-            <td rowspan="4" >
-<div class="nanotabs">
-  <ul>
-    <li><a href="#ex31-jsonld" class="selected">JSON-LD</a></li>
-    <li><a href="#ex31-microdata" class="selected">Microdata</a></li>
-    <li><a href="#ex31-rdfa" class="selected">RDFa</a></li>
 
-    <li><a href="#ex31-turtle" class="selected">Turtle</a></li>
-  </ul>
-  <div id="ex31-jsonld" style="display: block;">
-<pre class="example highlight json">{
-  "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
-  "actor": "acct:sally@example.org",
-  "object": "http://example.org/posts/1",
-  "target": "acct:john@example.org"
-}</pre>
-  </div>
-  <div id="ex31-microdata" style="display: none;">
-<pre class="example highlight html"
->&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
-  &lt;link itemprop="actor"
-    href="acct:sally@example.org">
-    Sally
-  &lt;/link>
-  shared
-  &lt;a itemprop="object"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link itemprop="target"
-    href="acct:john@example.org">
-    John
-  &lt;/link>
-&lt;/div></pre>
-  </div>
-  <div id="ex31-rdfa" style="display: none;">
-<pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
-  &lt;link property="actor"
-    href="acct:sally@example.org">
-    Sally
-  &lt;/link>
-  shared
-  &lt;a property="object"
-    href="http://example.org/posts/1">
-    http://example.org/posts/1
-  &lt;/a>
-  with
-  &lt;link property="target"
-    href="acct:john@example.org">
-    John
-  &lt;/link>
-&lt;/div></pre>
-  </div>
-  <div id="ex31-turtle" style="display: none;">
-<pre class="example highlight turtle"
->@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
-
-_:b0 a as:Share ;
-  as:actor &lt;acct:sally@example.org&gt; ;
-  as:object &lt;http://example.org/posts/1&gt; ;
-  as:target &lt;acct:john@example.org&gt; .
-</pre>
-  </div>
-</div>
-            </td>
-          </tr>
-          <tr>
-            <td>Notes:</td>
-            <td>
-              Indicates that the <code>actor</code> is sharing the
-              <code>object</code>. If specified, the <code>target</code>
-              indicates to context or entity to which the <code>object</code>
-              is being shared. The <code>origin</code> typically has no defined
-              meaning.
-            </td>
-          </tr>
-          <tr>
-            <td>Extends:</td>
-            <td><code><a>Activity</a></code></td>
-          </tr>
-          <tr>
-            <td>Properties:</td>
-            <td>Inherits all properties from <code><a>Activity</a></code>.</td>
-          </tr>
-        </tbody>
         <tbody>
           <tr>
             <td rowspan="4" ><dfn>Undo</dfn></td>
@@ -3578,7 +3483,7 @@ _:b0 a as:Share ;
   "@type": "Undo",
   "actor": "acct:sally@example.org",
   "object": {
-    "@type": "Share",
+    "@type": "Offer",
     "actor": "acct:sally@example.org",
     "object": "http://example.org/posts/1",
     "target": "acct:john@example.org"
@@ -3595,7 +3500,7 @@ _:b0 a as:Share ;
   &lt;/link>
   stopped
   &lt;span itemprop="object" itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
+  itemtype="http://www.w3.org/ns/activitystreams#Offer">
     &lt;link itemprop="actor"
     href="acct:sally@example.org" />
     sharing
@@ -3620,7 +3525,7 @@ _:b0 a as:Share ;
     Sally
   &lt;/link>
   stopped
-  &lt;span property="object" typeof="Share">
+  &lt;span property="object" typeof="Offer">
     &lt;link property="actor"
     href="acct:sally@example.org" />
     sharing
@@ -3643,7 +3548,7 @@ _:b0 a as:Share ;
 _:b0 a as:Undo ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object [
-    a as:Share ;
+    a as:Offer ;
     as:actor &lt;acct:sally@example.org&gt; ;
     as:object &lt;http://example.org/posts/1&gt; ;
     as:target &lt;acct:john@example.org&gt; .
@@ -7264,7 +7169,7 @@ _:b0 a as:Profile ;
   <div id="ex59-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
+  "@type": "Offer",
   "actor": "acct:sally@example.org",
   "object": "http://example.org/foo"
 }</pre>
@@ -7272,10 +7177,10 @@ _:b0 a as:Profile ;
 <div id="ex59-microdata" style="display:none;">
 <pre class="example highlight html"
 >&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
+  itemtype="http://www.w3.org/ns/activitystreams#Offer">
   &lt;link itemprop="actor"
     href="acct:sally@example.org">Sally&lt;/link>
-  shared
+  offered
   &lt;a itemprop="object"
     href="http://example.org/foo">
     http://example.org/foo
@@ -7285,10 +7190,10 @@ _:b0 a as:Profile ;
   <div id="ex59-rdfa" style="display:none;">
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
+  typeof="Offer">
   &lt;link property="actor"
     href="acct:sally@example.org">Sally&lt;/link>
-  shared
+  offered
   &lt;a property="object"
     href="http://example.org/foo">
     http://example.org/foo
@@ -7299,7 +7204,7 @@ _:b0 a as:Profile ;
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 
-_:b0 a as:Share ;
+_:b0 a as:Offer ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object &lt;http://example.org/foo&gt; .</pre>
   </div>
@@ -7317,7 +7222,7 @@ _:b0 a as:Share ;
   <div id="ex60-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
+  "@type": "Offer",
   "actor": {
     "@type": "Person",
     "@id": "acct:sally@example.org",
@@ -7329,13 +7234,13 @@ _:b0 a as:Share ;
 <div id="ex60-microdata" style="display:none;">
 <pre class="example highlight html"
 >&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
+  itemtype="http://www.w3.org/ns/activitystreams#Offer">
   &lt;span itemprop="actor" itemscope
     itemtype="http://www.w3.org/ns/activitystreams#Person"
     itemid="acct:sally@example.org">
     &lt;span itemprop="displayName">Sally&lt;/span>
   &lt;/span>
-  shared
+  offered
   &lt;a itemprop="object"
     href="http://example.org/foo">
     http://example.org/foo
@@ -7345,12 +7250,12 @@ _:b0 a as:Share ;
   <div id="ex60-rdfa" style="display:none;">
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
+  typeof="Offer">
   &lt;span property="actor" typeof="Person"
     resource="acct:sally@example.org">
     &lt;span property="displayName">Sally&lt;/span>
   &lt;/span>
-  shared
+  offered
   &lt;a property="object"
     href="http://example.org/foo">
     http://example.org/foo
@@ -7364,7 +7269,7 @@ _:b0 a as:Share ;
 &lt;acct:sally@example.org&gt; a as:Person ;
   as:displayName "Sally" .
 
-_:b0 a as:Share ;
+_:b0 a as:Offer ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object &lt;http://example.org/foo&gt; .</pre>
   </div>
@@ -7381,7 +7286,7 @@ _:b0 a as:Share ;
   <div id="ex61-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
+  "@type": "Offer",
   "actor": [
     "acct:joe@example.org",
     {
@@ -7396,7 +7301,7 @@ _:b0 a as:Share ;
 <div id="ex61-microdata" style="display:none;">
 <pre class="example highlight html"
 >&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
+  itemtype="http://www.w3.org/ns/activitystreams#Offer">
   &lt;link itemprop="actor"
     href="acct:joe@example.org">Joe&lt;/link>
   and
@@ -7405,7 +7310,7 @@ _:b0 a as:Share ;
     itemid="acct:sally@example.org">
     &lt;span itemprop="displayName">Sally&lt;/span>
   &lt;/span>
-  shared
+  offered
   &lt;a itemprop="object"
     href="http://example.org/foo">
     http://example.org/foo
@@ -7415,7 +7320,7 @@ _:b0 a as:Share ;
   <div id="ex61-rdfa" style="display:none;">
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
+  typeof="Offer">
   &lt;link property="actor"
     href="acct:joe@example.org">Joe&lt;/link>
   and
@@ -7423,7 +7328,7 @@ _:b0 a as:Share ;
     resource="acct:sally@example.org">
     &lt;span property="displayName">Sally&lt;/span>
   &lt;/span>
-  shared
+  offered
   &lt;a property="object"
     href="http://example.org/foo">
     http://example.org/foo
@@ -7437,7 +7342,7 @@ _:b0 a as:Share ;
 &lt;acct:sally@example.org&gt; a as:Person ;
   as:displayName "Sally" .
 
-_:b0 a as:Share ;
+_:b0 a as:Offer ;
   as:actor (
     &lt;acct:sally@example.org&gt;
     &lt;acct:joe@example.org&gt;
@@ -7743,7 +7648,7 @@ _:b0 a as:Image ;
   <div id="ex68-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
+  "@type": "Offer",
   "actor": "acct:sally@example.org",
   "object": "http://example.org/posts/1",
   "target": "acct:john@example.org",
@@ -7753,12 +7658,12 @@ _:b0 a as:Image ;
   <div id="ex68-microdata" style="display: none;">
 <pre class="example highlight html"
 >&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
+  itemtype="http://www.w3.org/ns/activitystreams#Offer">
   &lt;link itemprop="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a itemprop="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -7777,12 +7682,12 @@ _:b0 a as:Image ;
   <div id="ex68-rdfa" style="display: none;">
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
+  typeof="Offer">
   &lt;link property="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a property="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -7802,7 +7707,7 @@ _:b0 a as:Image ;
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 
-_:b0 a as:Share ;
+_:b0 a as:Offer ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object &lt;http://example.org/posts/1&gt; ;
   as:target &lt;acct:john@example.org&gt; ;
@@ -7846,7 +7751,7 @@ _:b0 a as:Share ;
   <div id="ex69-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
+  "@type": "Offer",
   "actor": "acct:sally@example.org",
   "object": "http://example.org/posts/1",
   "target": "acct:john@example.org",
@@ -7856,12 +7761,12 @@ _:b0 a as:Share ;
   <div id="ex69-microdata" style="display: none;">
 <pre class="example highlight html"
 >&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
+  itemtype="http://www.w3.org/ns/activitystreams#Offer">
   &lt;link itemprop="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a itemprop="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -7880,12 +7785,12 @@ _:b0 a as:Share ;
   <div id="ex69-rdfa" style="display: none;">
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
+  typeof="Offer">
   &lt;link property="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a property="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -7905,7 +7810,7 @@ _:b0 a as:Share ;
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 
-_:b0 a as:Share ;
+_:b0 a as:Offer ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object &lt;http://example.org/posts/1&gt; ;
   as:target &lt;acct:john@example.org&gt; ;
@@ -7949,7 +7854,7 @@ _:b0 a as:Share ;
   <div id="ex70-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
+  "@type": "Offer",
   "actor": "acct:sally@example.org",
   "object": "http://example.org/posts/1",
   "target": "acct:john@example.org",
@@ -7959,12 +7864,12 @@ _:b0 a as:Share ;
   <div id="ex70-microdata" style="display: none;">
 <pre class="example highlight html"
 >&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
+  itemtype="http://www.w3.org/ns/activitystreams#Offer">
   &lt;link itemprop="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a itemprop="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -7983,12 +7888,12 @@ _:b0 a as:Share ;
   <div id="ex70-rdfa" style="display: none;">
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
+  typeof="Offer">
   &lt;link property="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a property="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -8008,7 +7913,7 @@ _:b0 a as:Share ;
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 
-_:b0 a as:Share ;
+_:b0 a as:Offer ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object &lt;http://example.org/posts/1&gt; ;
   as:target &lt;acct:john@example.org&gt; ;
@@ -8055,7 +7960,7 @@ _:b0 a as:Share ;
   "@type": "Collection",
   "items": [
     {
-      "@type": "Share",
+      "@type": "Offer",
       "actor": "acct:sally@example.org",
       "object": "http://example.org/posts/1",
       "target": "acct:john@example.org",
@@ -8075,12 +7980,12 @@ _:b0 a as:Share ;
 >&lt;div itemscope itemtype="http://www.w3.org/ns/activitystreams#Collection">
   &lt;ul>
     &lt;li itemprop="items" itemscope
-      itemtype="http://www.w3.org/ns/activitystreams#Share">
+      itemtype="http://www.w3.org/ns/activitystreams#Offer">
       &lt;span itemprop="actor"
         itemid="acct:sally@example.org">
           Sally
       &lt;span>
-      shared
+      offered
       &lt;a itemprop="object"
         href="http://example.org/posts/1">
         http://example.org/posts/1
@@ -8115,12 +8020,12 @@ _:b0 a as:Share ;
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#"
   typeof="Collection">
   &lt;ul>
-    &lt;li property="items" typeof="Share">
+    &lt;li property="items" typeof="Offer">
       &lt;span property="actor"
         resource="acct:sally@example.org">
           Sally
       &lt;span>
-      shared
+      offered
       &lt;a property="object"
         href="http://example.org/posts/1">
         http://example.org/posts/1
@@ -8156,7 +8061,7 @@ _:b0 a as:Share ;
 _:b0 a as:Collection ;
   as:items ( _:b1 _:b2 ) .
 
-_:b1 a as:Share ;
+_:b1 a as:Offer ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object &lt;http://example.org/posts/1&gt; ;
   as:target &lt;acct:john@example.org&gt; ;
@@ -11592,7 +11497,7 @@ _:b0 a as:Image ;
   <div id="ex120-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
+  "@type": "Offer",
   "actor": "acct:sally@example.org",
   "object": "http://example.org/posts/1",
   "target": "acct:john@example.org"
@@ -11601,12 +11506,12 @@ _:b0 a as:Image ;
   <div id="ex120-microdata" style="display: none;">
 <pre class="example highlight html"
 >&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
+  itemtype="http://www.w3.org/ns/activitystreams#Offer">
   &lt;link itemprop="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a itemprop="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -11621,12 +11526,12 @@ _:b0 a as:Image ;
   <div id="ex120-rdfa" style="display: none;">
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
+  typeof="Offer">
   &lt;link property="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a property="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -11642,7 +11547,7 @@ _:b0 a as:Image ;
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 
-_:b0 a as:Share ;
+_:b0 a as:Offer ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object &lt;http://example.org/posts/1&gt; ;
   as:target &lt;acct:john@example.org&gt; .
@@ -11661,7 +11566,7 @@ _:b0 a as:Share ;
   <div id="ex121-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
+  "@type": "Offer",
   "actor": "acct:sally@example.org",
   "object": "http://example.org/posts/1",
   "target": {
@@ -11673,12 +11578,12 @@ _:b0 a as:Share ;
   <div id="ex121-microdata" style="display: none;">
 <pre class="example highlight html"
 >&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
+  itemtype="http://www.w3.org/ns/activitystreams#Offer">
   &lt;link itemprop="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a itemprop="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -11693,12 +11598,12 @@ _:b0 a as:Share ;
   <div id="ex121-rdfa" style="display: none;">
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
+  typeof="Offer">
   &lt;link property="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a property="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -11714,7 +11619,7 @@ _:b0 a as:Share ;
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 
-_:b0 a as:Share ;
+_:b0 a as:Offer ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object &lt;http://example.org/posts/1&gt; ;
   as:target [
@@ -11764,7 +11669,7 @@ _:b0 a as:Share ;
   <div id="ex123-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
+  "@type": "Offer",
   "actor": "acct:sally@example.org",
   "object": "http://example.org/posts/1",
   "target": "acct:john@example.org",
@@ -11774,12 +11679,12 @@ _:b0 a as:Share ;
   <div id="ex123-microdata" style="display: none;">
 <pre class="example highlight html"
 >&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
+  itemtype="http://www.w3.org/ns/activitystreams#Offer">
   &lt;link itemprop="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a itemprop="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -11798,12 +11703,12 @@ _:b0 a as:Share ;
   <div id="ex123-rdfa" style="display: none;">
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
+  typeof="Offer">
   &lt;link property="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a property="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -11823,7 +11728,7 @@ _:b0 a as:Share ;
 <pre class="example highlight turtle"
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt .
 
-_:b0 a as:Share ;
+_:b0 a as:Offer ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object &lt;http://example.org/posts/1&gt; ;
   as:target &lt;acct:john@example.org&gt; ;
@@ -13397,7 +13302,7 @@ _:b0 a as:Link ;
   <div id="ex143-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
+  "@type": "Offer",
   "actor": "acct:sally@example.org",
   "object": "http://example.org/posts/1",
   "target": "acct:john@example.org",
@@ -13407,12 +13312,12 @@ _:b0 a as:Link ;
   <div id="ex143-microdata" style="display: none;">
 <pre class="example highlight html"
 >&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
+  itemtype="http://www.w3.org/ns/activitystreams#Offer">
   &lt;link itemprop="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a itemprop="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -13428,12 +13333,12 @@ _:b0 a as:Link ;
   <div id="ex143-rdfa" style="display: none;">
 <pre class="example highlight html"
 >&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Share">
+  typeof="Offer">
   &lt;link property="actor"
     href="acct:sally@example.org">
     Sally
   &lt;/link>
-  shared
+  offered
   &lt;a property="object"
     href="http://example.org/posts/1">
     http://example.org/posts/1
@@ -13451,7 +13356,7 @@ _:b0 a as:Link ;
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 @prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt; .
 
-_:b0 a as:Share ;
+_:b0 a as:Offer ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object &lt;http://example.org/posts/1&gt; ;
   as:target &lt;acct:john@example.org&gt; ;

--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -866,7 +866,7 @@ value of <code>object</code> is not:</figcaption>
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
   "@id": "http://example.org/foo",
-  "@type": "Share",
+  "@type": "Create",
   "displayName": "A Test",
   "actor": {
     "@type": "Person",
@@ -881,7 +881,7 @@ value of <code>object</code> is not:</figcaption>
   </div>
   <div id="ex5-microdata" style="display: none;">
 <pre class="example highlight html"
->&lt;div itemscope itemtype="http://www.w3.org/ns/activitystreams#Share"
+>&lt;div itemscope itemtype="http://www.w3.org/ns/activitystreams#Create"
   itemid="http://example.org/foo">
   &lt;div itemprop="displayName">A Test&lt;/div>
   &lt;div itemprop="actor" itemscope
@@ -897,7 +897,7 @@ value of <code>object</code> is not:</figcaption>
 &lt;/div></pre></div>
   <div id="ex5-rdfa" style="display: none;">
 <pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Share"
+>&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Create"
   resource="http://example.org/foo">
   &lt;div property="displayName">A Test&lt;/div>
   &lt;div property="actor" itemscope typeof="Person"
@@ -917,7 +917,7 @@ value of <code>object</code> is not:</figcaption>
 &lt;http://example.org/~sally&gt; a as:Person ;
   as:displayName "Sally" .
 
-&lt;http://example.org/foo&gt; a as:Share ;
+&lt;http://example.org/foo&gt; a as:Create ;
   as:displayName "A Test" ;
   as:actor &lt;http://example.org/~sally&gt; ;
   as:object [
@@ -1661,7 +1661,7 @@ _:b0 a as:Object ;
   <div id="ex16-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "@type": "Share",
+  "@type": "Create",
   "actor": {
     "@type": "Person",
     "@id": "acct:sally@example.org",
@@ -1675,13 +1675,13 @@ _:b0 a as:Object ;
 </div>
   <div id="ex16-microdata" style="display:none;">
 <pre class="example highlight html"
->&lt;div itemscope itemtype="http://www.w3.org/ns/activitystreams#Share">
+>&lt;div itemscope itemtype="http://www.w3.org/ns/activitystreams#Create">
   &lt;div itemprop="actor" itemscope
     itemtype="http://www.w3.org/ns/activitystreams#Person"
     itemid="acct:sally@example.org">
     &lt;span itemprop="displayName">Sally Smith&lt;/span>
   &lt;/div>
-  Shared
+  created
   &lt;div itemprop="object" itemscope
     itemtype="http://www.w3.org/ns/activitystreams#Note">
     "&lt;span itemprop="content">This is a simple note&lt;/span>"
@@ -1689,12 +1689,12 @@ _:b0 a as:Object ;
 &lt;/div></pre></div>
   <div id="ex16-rdfa" style="display:none;">
 <pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Share">
+>&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Create">
   &lt;div property="actor" typeof="Person"
     resource="acct:sally@example.org">
     &lt;span property="displayName">Sally Smith&lt;/span>
   &lt;/div>
-  Shared
+  created
   &lt;div property="object" typeof="Note">
     "&lt;span property="content">This is a simple note&lt;/span>"
   &lt;/div>
@@ -1705,7 +1705,7 @@ _:b0 a as:Object ;
   &lt;acct:sally@example.org&gt; a as:Person ;
   as:displayName "Sally Smith" .
 
-_:b0 a as:Share ;
+_:b0 a as:Create ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object [
     a as:Note ;
@@ -1728,7 +1728,7 @@ _:b0 a as:Share ;
     "http://www.w3.org/ns/activitystreams",
     {"vcard": "http://www.w3.org/2006/vcard/ns#"}
   ],
-  "@type": "Share",
+  "@type": "Create",
   "actor": {
     "@type": "Person",
     "@id": "acct:sally@example.org",
@@ -1744,7 +1744,7 @@ _:b0 a as:Share ;
 </div>
   <div id="ex17-microdata" style="display:none;">
 <pre class="example highlight html"
->&lt;div itemscope itemtype="http://www.w3.org/ns/activitystreams#Share">
+>&lt;div itemscope itemtype="http://www.w3.org/ns/activitystreams#Create">
   &lt;div itemprop="actor" itemscope
     itemtype="http://www.w3.org/ns/activitystreams#Person"
     itemid="acct:sally@example.org">
@@ -1753,7 +1753,7 @@ _:b0 a as:Share ;
       &lt;span itemprop="http://www.w3.org/2006/vcard/ns#family-name">Smith&lt;/span>
     &lt;/span>
   &lt;/div>
-  Shared
+  created
   &lt;div itemprop="object" itemscope
     itemtype="http://www.w3.org/ns/activitystreams#Note">
     "&lt;span itemprop="content">This is a simple note&lt;/span>"
@@ -1761,13 +1761,13 @@ _:b0 a as:Share ;
 &lt;/div></pre></div>
   <div id="ex17-rdfa" style="display:none;">
 <pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Share">
+>&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Create">
   &lt;div property="actor" typeof="Person"
     resource="acct:sally@example.org">
       &lt;span property="http://www.w3.org/2006/vcard/ns#given-name">Sally&lt;/span>
       &lt;span property="http://www.w3.org/2006/vcard/ns#family-name">Smith&lt;/span>
   &lt;/div>
-  Shared
+  created
   &lt;div property="object" typeof="Note">
     "&lt;span property="content">This is a simple note&lt;/span>"
   &lt;/div>
@@ -1782,7 +1782,7 @@ _:b0 a as:Share ;
   vcard:given-name "Sally" ;
   vcard:family-name "Smith" .
 
-_:c14n0 a as:Share ;
+_:c14n0 a as:Create ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object [
     a as:Note ;
@@ -1819,7 +1819,7 @@ _:c14n0 a as:Share ;
     "http://www.w3.org/ns/activitystreams",
     {"vcard": "http://www.w3.org/2006/vcard/ns#"}
   ],
-  "@type": "Share",
+  "@type": "Create",
   "actor": {
     "@type": ["Person", "vcard:Individual"],
     "@id": "acct:sally@example.org",
@@ -1836,7 +1836,7 @@ _:c14n0 a as:Share ;
   <div id="ex18-microdata" style="display:none;">
 <pre class="example highlight html"
 >&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Share">
+  itemtype="http://www.w3.org/ns/activitystreams#Create">
   &lt;div itemprop="actor" itemscope
     itemtype="
       http://www.w3.org/ns/activitystreams#Person
@@ -1847,7 +1847,7 @@ _:c14n0 a as:Share ;
       &lt;span itemprop="http://www.w3.org/2006/vcard/ns#family-name">Smith&lt;/span>
     &lt;/span>
   &lt;/div>
-  Shared
+  created
   &lt;div itemprop="object" itemscope
     itemtype="http://www.w3.org/ns/activitystreams#Note">
     "&lt;span itemprop="content">This is a simple note&lt;/span>"
@@ -1855,13 +1855,13 @@ _:c14n0 a as:Share ;
 &lt;/div></pre></div>
   <div id="ex18-rdfa" style="display:none;">
 <pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Share">
+>&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Create">
   &lt;div property="actor" typeof="Person http://www.w3.org/2006/vcard/ns#Individual"
     resource="acct:sally@example.org">
       &lt;span property="http://www.w3.org/2006/vcard/ns#given-name">Sally&lt;/span>
       &lt;span property="http://www.w3.org/2006/vcard/ns#family-name">Smith&lt;/span>
   &lt;/div>
-  Shared
+  created
   &lt;div property="object" typeof="Note">
     "&lt;span property="content">This is a simple note&lt;/span>"
   &lt;/div>
@@ -1876,7 +1876,7 @@ _:c14n0 a as:Share ;
   vcard:given-name "Sally" ;
   vcard:family-name "Smith" .
 
-_:b0 a as:Share ;
+_:b0 a as:Create ;
   as:actor &lt;acct:sally@example.org&gt; ;
   as:object [
     a as:Note ;
@@ -1987,7 +1987,7 @@ _:b0 a as:Share ;
         should be taken to not unduly overlap with or duplicate the existing
         Activity types. For instance, some vocabularies (e.g. Schema.org) define
         their own classes for describing actions. An implementation that wishes,
-        for example, to use <code><a href="http://schema.org/ShareAction">http://schema.org/LikeAction</a></code>
+        for example, to use <code><a href="http://schema.org/LikeAction">http://schema.org/LikeAction</a></code>
         as an Activity SHOULD identify that Object as being both a
         <code><a href="activitystreams2-vocabulary.html#dfn-like">Like</a></code>
         and an <code>http://schema.org/LikeAction</code>, as illustrated in the

--- a/activitystreams2.owl
+++ b/activitystreams2.owl
@@ -1014,11 +1014,6 @@ as:Service a owl:Class ;
   rdfs:subClassOf as:Actor ;
   rdfs:comment "A service provided by some entity"@en .
 
-as:Share a owl:Class ;
-  rdfs:label "Share"@en ;
-  rdfs:subClassOf as:Activity ;
-  rdfs:comment "To Share Something with Someone"@en .
-
 as:Story a owl:Class ;
   rdfs:label "Story"@en ;
   rdfs:subClassOf as:OrderedCollection ;


### PR DESCRIPTION
The "Share" activity creates some confusion. In many common
cases, a "Share" is really just a normal post targeted at
specific people, which can be accomplished using the audience
targeting mechanism along with "Announce". Removing "Share"
allows us to eliminate a confusing element in the vocabulary.