### PR TITLE
remove "Respond"

### DIFF
--- a/activitystreams2-context.jsonld
+++ b/activitystreams2-context.jsonld
@@ -59,7 +59,6 @@
     "View": "as:View",
     "Listen": "as:Listen",
     "Read": "as:Read",
-    "Respond": "as:Respond",
     "Move": "as:Move",
     "Travel": "as:Travel",
     "a": {

--- a/activitystreams2-vocabulary.html
+++ b/activitystreams2-vocabulary.html
@@ -1038,8 +1038,8 @@ _:b0 a as:OrderedCollection ;
         All Activity Types inherit the properties of the base <a>Activity</a>
         class. Some specific Activity Types are subclasses or specializations
         of more generalized Activity Types (for instance, the
-        <code><a>Like</a></code> Activity Type is a more specific form of the
-        <code><a>Respond</a></code> Activity Type).
+        <code><a>Invite</a></code> Activity Type is a more specific form of the
+        <code><a>Offer</a></code> Activity Type).
       </p>
 
       <p>
@@ -1070,7 +1070,6 @@ _:b0 a as:OrderedCollection ;
         <code><a>Reject</a></code> |
         <code><a>Read</a></code> |
         <code><a>Remove</a></code> |
-        <code><a>Respond</a></code> |
         <code><a>TentativeReject</a></code> |
         <code><a>TentativeAccept</a></code> |
         <code><a>Travel</a></code> |
@@ -1087,110 +1086,6 @@ _:b0 a as:OrderedCollection ;
             <th style="width: 40%">Example</th>
           </tr>
         </thead>
-        <tbody>
-           <tr>
-             <td rowspan="4" ><dfn>Respond</dfn></td>
-             <td  style="width: 10%">URI:</td>
-             <td><code>http://www.w3.org/ns/activitystreams#Respond</code></td>
-             <td rowspan="4" >
- <div class="nanotabs">
-   <ul>
-     <li><a href="#ex165-jsonld" class="selected">JSON-LD</a></li>
-     <li><a href="#ex165-microdata" class="selected">Microdata</a></li>
-     <li><a href="#ex165-rdfa" class="selected">RDFa</a></li>
-     <li><a href="#ex165-turtle" class="selected">Turtle</a></li>
-   </ul>
-   <div id="ex165-jsonld" style="display: block;">
- <pre class="example highlight json">{
-   "@context": "http://www.w3.org/ns/activitystreams",
-   "@type": "Respond",
-   "actor": {
-     "@type": "Person",
-     "displayName": "Sally"
-   },
-   "object": "http://example.org/posts/1",
-   "result": {
-     "@type": "Note",
-     "content": "This is a good article",
-     "inReplyTo": "http://example.org/posts/1"
-   }
- }</pre>
- </div>
- <div id="ex165-microdata" style="display:none;">
- <pre class="example highlight html"
- >&lt;div itemscope
-   itemtype="http://www.w3.org/ns/activitystreams#Respond">
-   &lt;span itemprop="actor" itemscope
-     itemtype="http://www.w3.org/ns/activitystreams#Person">
-     &lt;span itemprop="displayName">Sally&lt;/span>
-   &lt;/span>
-   responded to
-   &lt;a itemprop="object"
-     href="http://example.org/posts/1">
-     "http://example.org/posts/1"
-   &lt;/a>
-   with
-   &lt;span itemprop="result" itemscope
-     itemtype="http://www.w3.org/ns/activitystreams#Note">
-     &lt;link itemprop="inReplyTo" href="http://example.org/posts/1" />
-     "&lt;span itemprop="content">This is a good article&lt;/span>"
-   &lt;/span>
- &lt;/div></pre>
-   </div>
-   <div id="ex165-rdfa" style="display:none;">
- <pre class="example highlight html"
- >&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-   typeof="Respond">
-   &lt;span property="actor" typeof="Person">
-     &lt;span property="displayName">Sally&lt;/span>
-   &lt;/span>
-   responded to
-   &lt;a property="object"
-     href="http://example.org/posts/1">
-     "http://example.org/posts/1"
-   &lt;/a>
-   with
-   &lt;span property="result" typeof="Note">
-     &lt;link property="inReplyTo" href="http://example.org/posts/1" />
-     "&lt;span property="content">This is a good article&lt;/span>"
-   &lt;/span>
- &lt;/div></pre>
-   </div>
- <div id="ex165-turtle" style="display: none;">
- <pre class="example highlight turtle">
- @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
-
- _:b0 a as:Respond ;
-   as:actor [
-     a as:Person ;
-       as:displayName "Sally" .
-   ] ;
-   as:object &lt;http://example.org/posts/1&gt; ;
-   as:result [
-     a as:Note ;
-       as:content "This is a good article" ;
-       as:inReplyTo &lt;http://example.org/posts/1&gt; .
-   ].</pre>
-   </div>
- </div>
-             </td>
-           </tr>
-           <tr>
-             <td>Notes:</td>
-             <td>
-               Indicates that the <code>actor</code> has reponded to the
-               <code>object</code>.
-             </td>
-           </tr>
-           <tr>
-             <td>Extends:</td>
-             <td><code><a>Activity</a></code></td>
-           </tr>
-           <tr>
-             <td>Properties:</td>
-             <td>Inherits all properties from <code><a>Activity</a></code>.</td>
-           </tr>
-         </tbody>
         <tbody>
           <tr>
             <td rowspan="4" ><dfn>Accept</dfn></td>
@@ -1304,11 +1199,11 @@ _:b0 a as:Accept ;
           </tr>
           <tr>
             <td>Extends:</td>
-            <td><code><a>Respond</a></code></td>
+            <td><code><a>Activity</a></code></td>
           </tr>
           <tr>
             <td>Properties:</td>
-            <td>Inherits all properties from <code><a>Respond</a></code>.</td>
+            <td>Inherits all properties from <code><a>Activity</a></code>.</td>
           </tr>
         </tbody>
         <tbody>
@@ -1965,11 +1860,11 @@ _:b0 a as:Favorite ;
           </tr>
           <tr>
             <td>Extends:</td>
-            <td><code><a>Respond</a></code></td>
+            <td><code><a>Activity</a></code></td>
           </tr>
           <tr>
             <td>Properties:</td>
-            <td>Inherits all properties from <code><a>Respond</a></code>.</td>
+            <td>Inherits all properties from <code><a>Activity</a></code>.</td>
           </tr>
         </tbody>
         <tbody>
@@ -2143,11 +2038,11 @@ _:b0 a as:Ignore ;
           </tr>
           <tr>
             <td>Extends:</td>
-            <td><code><a>Respond</a></code></td>
+            <td><code><a>Activity</a></code></td>
           </tr>
           <tr>
             <td>Properties:</td>
-            <td>Inherits all properties from <code><a>Respond</a></code>.</td>
+            <td>Inherits all properties from <code><a>Activity</a></code>.</td>
           </tr>
         </tbody>
         <tbody>
@@ -2476,11 +2371,11 @@ _:b0 a as:Like ;
           </tr>
           <tr>
             <td>Extends:</td>
-            <td><code><a>Respond</a></code></td>
+            <td><code><a>Activity</a></code></td>
           </tr>
           <tr>
             <td>Properties:</td>
-            <td>Inherits all properties from <code><a>Respond</a></code>.</td>
+            <td>Inherits all properties from <code><a>Activity</a></code>.</td>
           </tr>
         </tbody>
         <tbody>
@@ -2813,11 +2708,11 @@ _:b0 a as:Reject ;
           </tr>
           <tr>
             <td>Extends:</td>
-            <td><code><a>Respond</a></code></td>
+            <td><code><a>Activity</a></code></td>
           </tr>
           <tr>
             <td>Properties:</td>
-            <td>Inherits all properties from <code><a>Respond</a></code>.</td>
+            <td>Inherits all properties from <code><a>Activity</a></code>.</td>
           </tr>
         </tbody>
         <tbody>
@@ -4213,11 +4108,11 @@ _:b0 a as:Flag ;
           </tr>
           <tr>
             <td>Extends:</td>
-            <td><code><a>Respond</a></code></td>
+            <td><code><a>Activity</a></code></td>
           </tr>
           <tr>
             <td>Properties:</td>
-            <td>Inherits all properties from <code><a>Respond</a></code>.</td>
+            <td>Inherits all properties from <code><a>Activity</a></code>.</td>
           </tr>
         </tbody>
 
@@ -4287,11 +4182,11 @@ _:b0 a as:Dislike ;
           </tr>
           <tr>
             <td>Extends:</td>
-            <td><code><a>Respond</a></code></td>
+            <td><code><a>Activity</a></code></td>
           </tr>
           <tr>
             <td>Properties:</td>
-            <td>Inherits all properties from <code><a>Respond</a></code>.</td>
+            <td>Inherits all properties from <code><a>Activity</a></code>.</td>
           </tr>
         </tbody>
 

--- a/activitystreams2.owl
+++ b/activitystreams2.owl
@@ -678,7 +678,7 @@ as:width a owl:DatatypeProperty ,
 
 as:Accept a owl:Class ;
   rdfs:label "Accept"@en ;
-  rdfs:subClassOf as:Respond ;
+  rdfs:subClassOf as:Activity ;
   rdfs:comment "Actor accepts the Object"@en .
 
 as:Activity a owl:Class ;
@@ -777,7 +777,7 @@ as:Delete a owl:Class ;
 
 as:Dislike a owl:Class ;
   rdfs:label "Dislike"@en;
-  rdfs:subClassOf as:Respond ;
+  rdfs:subClassOf as:Activity ;
   rdfs:comment "The actor dislikes the object"@en .
 
 as:Document a owl:Class ;
@@ -793,12 +793,12 @@ as:Event a owl:Class ;
 as:Favorite a owl:Class ;
   rdfs:label "Favorite"@en ;
   owl:equivalentClass as:Like ;
-  rdfs:subClassOf as:Respond ;
+  rdfs:subClassOf as:Activity ;
   rdfs:comment "To Favorite/Like Something"@en .
 
 as:Flag a owl:Class ;
   rdfs:label "Flag"@en;
-  rdfs:subClassOf as:Respond ;
+  rdfs:subClassOf as:Activity ;
   rdfs:comment "To flag something (e.g. flag as inappropriate, flag as spam, etc)"@en .
 
 as:Folder a owl:Class ;
@@ -818,7 +818,7 @@ as:Group a owl:Class ;
 
 as:Ignore a owl:Class ;
   rdfs:label "Ignore"@en ;
-  rdfs:subClassOf as:Respond ;
+  rdfs:subClassOf as:Activity ;
   rdfs:comment "Actor is ignoring the Object"@en .
 
 as:Image a owl:Class ;
@@ -843,7 +843,7 @@ as:Leave a owl:Class ;
 
 as:Like a owl:Class ;
   rdfs:label "Like"@en ;
-  rdfs:subClassOf as:Respond ;
+  rdfs:subClassOf as:Activity ;
   rdfs:comment "To Like/Favorite Something"@en .
 
 as:Experience a owl:Class;
@@ -865,11 +865,6 @@ as:Read a owl:Class ;
   rdfs:label "Read"@en ;
   rdfs:subClassOf as:Experience ;
   rdfs:comment "The actor read the object"@en .
-
-as:Respond a owl:Class ;
-  rdfs:label "Respond"@en ;
-  rdfs:subClassOf as:Activity ;
-  rdfs:comment "The actor responded to the object"@en .
 
 as:Move a owl:Class ;
   rdfs:label "Move"@en ;
@@ -986,7 +981,7 @@ as:Question a owl:Class ;
 
 as:Reject a owl:Class ;
   rdfs:label "Reject"@en ;
-  rdfs:subClassOf as:Respond ;
+  rdfs:subClassOf as:Activity ;
   rdfs:comment "Actor rejects the Object"@en .
 
 as:Remove a owl:Class ;


### PR DESCRIPTION
The "Respond" activity type was added speculatively as a
superclass of a set of more specific Activity types like
"Like", "Dislike", etc. Since it was added, the decision
was made not to require support for inferencing, making
it largely unnecessary to define a hierarchy of responses.
None of our user stories justify having a separate generic
"Respond" activity and we already have "in-reply-to" as
a property.