### PR TITLE
"Social" Web -> social Web

### DIFF
--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -775,7 +775,7 @@ _:b0 a as:Collection ;
       The <a href="activitystreams2-vocabulary.html">Activity Vocabulary</a>
       defines the abstract model for Activity Streams 2.0. The vocabulary
       is segmented into a set of seven core classes and an extended set of
-      Activity and Object types common to most "Social" Web applications. The
+      Activity and Object types common to most social Web applications. The
       core classes include:
         <a>Object</a>,
         <a>Link</a>,
@@ -1025,7 +1025,7 @@ value of <code>object</code> is not:</figcaption>
      <p>
        The <a href="activitystreams2-vocabulary.html">Activity Vocabulary</a>
        defines a broad range of <code>Object</code> types that are common to
-       many "Social" Web applications. This specification stops short of
+       many social Web applications. This specification stops short of
        defining semantically specific properties for most of these objects.
        External vocabularies can be used to express additional detail not
        covered by the Activity Vocabulary.
@@ -2203,7 +2203,7 @@ _:b0 a as:Create ;
       <p>
         The <a href="activitystreams2-vocabulary.html">Activity Vocabulary</a>
         defines a broad range of <code>Activity</code> types that are common to
-        many "Social" Web applications. This specification stops short of
+        many social Web applications. This specification stops short of
         defining semantically specific properties for most of these activities.
         External vocabularies can be used to express additional detail not
         covered by the Activity Vocabulary.


### PR DESCRIPTION
Putting "Social" in quotes feels like it's introducing more questions than needed. We know that there's a Social Web Working Group, so talking about social Web applications isn't that questionable. I lowercased "Social" to "social" since I think we're talking about a common noun (social application using the Web) rather than a proper noun (application on the Social Web).