### PR TITLE
Lowercase and <code> for actor

### DIFF
--- a/activitystreams2-vocabulary.html
+++ b/activitystreams2-vocabulary.html
@@ -7642,8 +7642,8 @@ _:b0 a as:Offer ;
           <td>
             Describes one or more entities that either performed or are
             expected to perform the activity. Any single activity can have
-            multiple Actors. The Actor MAY be specified using an indirect
-            <code><a>Link</a></code>.
+            multiple <code>actor</code>s. The <code>actor</actor> MAY be
+            specified using an indirect <code><a>Link</a></code>.
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
Lowercased and &lt;code&gt;d the name of the actor property to differentiate
it from the Actor class.