### PR TITLE
common to all Object's -> common to all Objects

### DIFF
--- a/activitystreams2.html
+++ b/activitystreams2.html
@@ -1826,7 +1826,7 @@ _:b0 a as:Object ;
         generalized way, stopping short of defining semantically specific
         properties for each. All Actor objects are specializations of
         <code><a>Object</a></code> and inherit all of the core properties
-        common to all Object's. External vocabularies (VCard for instance) can
+        common to all Objects. External vocabularies (VCard for instance) can
         be used to express additional detail not covered by the Activity
         Vocabulary.
       </p>


### PR DESCRIPTION
Correct the plural of "Object".