### PR TITLE
Another round of batched updates

### DIFF
--- a/activitystreams-core/activitystreams2-context.jsonld
+++ b/activitystreams-core/activitystreams2-context.jsonld
@@ -19,7 +19,6 @@
     "Collection": "as:Collection",
     "CollectionPage": "as:CollectionPage",
     "Relationship": "as:Relationship",
-    "Content": "as:Content",
     "Create": "as:Create",
     "Delete": "as:Delete",
     "Dislike": "as:Dislike",

--- a/activitystreams-core/index.html
+++ b/activitystreams-core/index.html
@@ -156,16 +156,16 @@
       </p>
 
       <p>
-        The terms <code>displayName</code>, <code>verb</code>, and
-        <code>objectType</code> should be treated as reserved terms that
-        SHOULD NOT be used within Activity Streams 2.0 documents. When
-        encountered in an Activity Streams 2.0 document, they SHOULD be
-        processed in accordance to the guidelines listed in
+        The terms <code>displayName</code>, <code>verb</code>,
+        <code>title</code> and <code>objectType</code> should be treated as
+        reserved terms that SHOULD NOT be used within Activity Streams 2.0
+        documents. When encountered in an Activity Streams 2.0 document, they
+        SHOULD be processed in accordance to the guidelines listed in
         <a href="#activitystreams-1.0a"></a>
       </p>
 
     </section>
-
+  </section>
     <section id="syntaxconventions">
 
       <h2>Serialization</h2>
@@ -192,31 +192,6 @@
       </p>
 
       <p>
-        This specification uses IRIs [[!RFC3987]].  Every URI [[!RFC3986]] is
-        also an IRI, so a URI may be used wherever an IRI is named.  There are
-        two special considerations: (1) when an IRI that is not also a URI is
-        given for dereferencing, it MUST be mapped to a URI using the steps in
-        Section 3.1 of [[!RFC3987]] and (2) when an IRI is serving as an "id"
-        value, it MUST NOT be so mapped.
-      </p>
-
-      <p>
-        Relative IRI (and URL) references SHOULD NOT be used within an
-        Activity Streams 2.0 document due to the fact that many JSON
-        parser implementations are not capable of reliably preserving the base
-        context necessary to properly resolve relative references.
-      </p>
-
-      <p>
-        Unless otherwise specified, all properties with date and time values
-        MUST conform to the "date-time" production in [[!RFC3339]], with an
-        uppercase "T" character used to separate date and time, and an
-        uppercase "Z" character in the absence of a numeric time zone offset.
-        All such timestamps SHOULD be represented relative to Coordinated
-        Universal Time (UTC).
-      </p>
-
-      <p>
         An <dfn data-lt="Activity Streams Document">Activity Streams
         Document</dfn> is a JSON document whose root value is an
         Activity Streams <a>Object</a> of any type and whose MIME media
@@ -228,37 +203,94 @@
         character encoding.
       </p>
 
-      <p>
-        The serialized JSON form of an Activity Streams 2.0 document MUST
-        be consistent with what would be produced by the standard
-        JSON-LD 1.0 Processing Algorithms and API [[!JSON-LD-API]] Compaction
-        Algorithm using, at least, the normative JSON-LD @context definition
-        provided <a href="activitystreams2-context.jsonld">here</a>.
-        Implementations MAY augment the provided @context with additional
-        @context definitions but MUST NOT override or change the normative
-        context. Implementations MAY also use additional properties and values
-        not defined in the JSON-LD @context with the understanding that any
-        such properties will likely be unsupported and ignored by consuming
-        implementations that use the standard JSON-LD algorithms. See the
-        <a href="#extensibility">Extensibility</a> section for more information
-        on handling extensions within Activity Streams 2.0 documents.
-      </p>
+      <section id="jsonld">
+        <h3>JSON-LD</h3>
 
-      <p>
-        JSON-LD uses the special <code>@context</code> property to define the
-        <a href="http://www.w3.org/TR/json-ld/#the-context">processing
-        context</a>. The value of the <code>@context</code> property is defined
-        by the [[JSON-LD]] specification. Implementations producing Activity
-        Streams 2.0 documents SHOULD include a <code>@context</code> property
-        with a value that includes a reference to the normative
-        <a href="activitystreams2-context.jsonld">Activity Streams 2.0 JSON-LD
-        @context definition</a> using the URL
-        "<code>http://www.w3.org/ns/activitystreams</code>".
-      </p>
+        <p>
+          The serialized JSON form of an Activity Streams 2.0 document MUST
+          be consistent with what would be produced by the standard
+          JSON-LD 1.0 Processing Algorithms and API [[!JSON-LD-API]] Compaction
+          Algorithm using, at least, the normative JSON-LD @context definition
+          provided <a href="activitystreams2-context.jsonld">here</a>.
+          Implementations MAY augment the provided @context with additional
+          @context definitions but MUST NOT override or change the normative
+          context. Implementations MAY also use additional properties and values
+          not defined in the JSON-LD @context with the understanding that any
+          such properties will likely be unsupported and ignored by consuming
+          implementations that use the standard JSON-LD algorithms. See the
+          <a href="#extensibility">Extensibility</a> section for more information
+          on handling extensions within Activity Streams 2.0 documents.
+        </p>
+
+        <p>
+          JSON-LD uses the special <code>@context</code> property to define the
+          <a href="http://www.w3.org/TR/json-ld/#the-context">processing
+          context</a>. The value of the <code>@context</code> property is defined
+          by the [[JSON-LD]] specification. Implementations producing Activity
+          Streams 2.0 documents SHOULD include a <code>@context</code> property
+          with a value that includes a reference to the normative
+          <a href="activitystreams2-context.jsonld">Activity Streams 2.0 JSON-LD
+          @context definition</a> using the URL
+          "<code>http://www.w3.org/ns/activitystreams</code>".
+        </p>
+        
+        <p>
+          When a JSON-LD enabled Activity Streams 2.0 implementation encounters
+          a JSON document identified using the
+          "<code>application/activity+json</code>" MIME media type, and
+          that document does not contain a <code>@context</code> property
+          whose value includes a reference to the normative
+          <a href="activitystreams2-context.jsonld">Activity Streams 2.0 JSON-LD
+          @context definition</a>, the implementation MUST assume that the
+          normative @context definition still applies.
+        </p>
+      </section>
+      
+      <section id="urls">
+        <h3>IRIs and URLs</h3>
+ 
+        <p>
+          This specification uses IRIs [[!RFC3987]].  Every URI [[!RFC3986]] is
+          also an IRI, so a URI may be used wherever an IRI is named.  There are
+          two special considerations: (1) when an IRI that is not also a URI is
+          given for dereferencing, it MUST be mapped to a URI using the steps in
+          Section 3.1 of [[!RFC3987]] and (2) when an IRI is serving as an "id"
+          value, it MUST NOT be so mapped.
+        </p>
+
+        <p>
+          Relative IRI (and URL) references SHOULD NOT be used within an
+          Activity Streams 2.0 document due to the fact that many JSON
+          parser implementations are not capable of reliably preserving the base
+          context necessary to properly resolve relative references.
+        </p>
+      </section>
+
+      <section id="dates">
+        <h3>Date and Times</h3>
+        <p>
+          All properties with date and time values MUST conform to the
+          "date-time" production in [[!RFC3339]] with the one exception
+          that seconds MAY be omitted. An uppercase "T"
+          character MUST be used to separate date and time, and an
+          uppercase "Z" character MUST be used in the absence of a numeric time
+          zone offset.
+        </p>
+        <p>
+          This is specified using the following [[ABNF]] syntax description.
+          The "time-hour", "time-minute", "time-second", "time-secfrac",
+          "time-offset" and "full-date" constructs are as defined in
+          [[RFC3339]].
+        </p>
+<pre>
+as2-partial-time = time-hour ":" time-minute [":" time-second]
+                   [time-secfrac]
+as2-full-time    = as2-partial-time time-offset
+as2-date-time    = full-date "T" as2-full-time
+</pre>
+      </section>
 
     </section>
-
-  </section>
 
   <section id="examples" class="informative">
     <h2>Examples</h2>
@@ -825,6 +857,24 @@ _:b0 a as:Collection ;
         <li><a>OrderedCollectionPage</a>.</li>
       </ul>
     </p>
+    
+    <p>
+      Every JSON object in an Activity Streams 2.0 document is either an
+      <code><a>Object</a></code> or a <code><a>Link</a></code>. All other types
+      defined in the Activity Vocabulary, as well as all extension types, are
+      derived from these two base types.
+    </p>
+    
+    <p>
+      A JSON object in the Activity Streams 2.0 document is a
+      <code><a>Link</a></code> if either: (a) the object contains a
+      <code>type</code> property whose value includes "<code>Link</code>" or
+      (b) any of the types included in the value of the <code>type</code>
+      property are defined as extensions of <a>Link</a> (see
+      <a href="../activitystreams-vocabulary/#dfn-mention">Mention</a> for
+      instance); otherwise the JSON object is considered an instance
+      or extension of <code><a>Object</a></code>.
+    </p>
 
     <section id="object">
       <h2><dfn data-lt="Object" id="asobject">Object</dfn></h2>
@@ -962,15 +1012,9 @@ _:b0 a as:Collection ;
 </div>
 </figure>
 
-      <p>
-        Implementations MUST treat all object types in an Activity Streams
-        document as subclasses of <a>Object</a> unless the object is a
-        <a>Link</a>.
-      </p>
-
      <p>
        The <a href="../activitystreams-vocabulary/">Activity Vocabulary</a>
-       defines a broad range of <code>Object</code> types that are common to
+       defines a range of <code>Object</code> types that are common to
        many social Web applications. This specification stops short of
        defining semantically specific properties for most of these objects.
        External vocabularies can be used to express additional detail not
@@ -2375,7 +2419,7 @@ _:b0 a as:Object ;
         "<code>name</code>", "<code>summary</code>", and "<code>content</code>"
         represent the JSON string forms; and the terms
         "<code>nameMap</code>", "<code>summaryMap</code>", and
-        "<code>contentMap</code>" for representing the object forms.
+        "<code>contentMap</code>" for represent the object forms.
       </p>
 
       <p>
@@ -2427,7 +2471,7 @@ _:b0 a as:Object ;
       </div>
     </figure>
 
-      <section id="defaultlangcontext">
+      <!-- <section id="defaultlangcontext">
         <h3>Default Language Context</h3>
 
       <p>
@@ -2487,7 +2531,7 @@ _:b0 a as:Object ;
 </div>
 </figure>
 
-    </section>
+    </section> -->
 
     </section>
 
@@ -2498,9 +2542,10 @@ _:b0 a as:Object ;
     <h2>Extensibility</h2>
 
       <p>
-        In Activity Streams 2.0, an "extension" is any property not defined
-        by the <a href="../activitystreams-vocabulary/">Activity
-        Vocabulary</a>. Consuming implementations that encounter unfamiliar
+        In Activity Streams 2.0, an "extension" is any property, activity,
+        actor or object type not defined by the
+        <a href="../activitystreams-vocabulary/">Activity Vocabulary</a>.
+        Consuming implementations that encounter unfamiliar
         extensions MUST NOT stop processing or signal an error and MUST
         continue processing the items as if those properties were not
         present. Note that support for extensions can vary across
@@ -2666,9 +2711,9 @@ _:c14n0 a gsp:Geometry ;
     The JSON-LD syntax supports the use of "Compact URIs" (or CURIE's for
     short) [[!curie]]. A "Compact URI" is an alternative encoding of a URI that uses
     a defined prefix to simplify serialization. For instance, the URI
-    <code>http://www.w3.org/ns/activitystreams#Create</code> can be
-    represented as <code>as:Create</code> by assigning the <code>as:</code>
-    prefix the value of <code>http://www.w3.org/ns/activitystreams#</code>
+    <code>http://example.org/term</code> can be
+    represented as <code>ex:term</code> by assigning the <code>ex:</code>
+    prefix the value of <code>http://example.org/</code>
   </p>
 
   <p>
@@ -2706,22 +2751,14 @@ _:c14n0 a gsp:Geometry ;
     Activity Streams 2.0 implementations that wish to fully support extensions
     MUST support Compact URI expansion as defined by the JSON-LD specification.
     Such expansion applies to all property names as well as all property values
-    explicitly defined as type <code>id</code> in the normative
-    <a href="activitystreams2-context.jsonld">JSON-LD @context</a>.
+    explicitly defined as type <code>@id</code> in the JSON-LD @context.
   </p>
 
   <p>
-    For example, in the JSON-LD serialization, the property name
-    <code>name</code> expands, and is equivalent, to
-    <code>http://www.w3.org/ns/activitystreams#name</code>.
-  </p>
-
-  <p>
-    While support for Compact URI's is required, over reliance on the
-    compact form can lead to ambiguity and interoperability issues between
-    implementations. Therefore, Compact URI use SHOULD be avoided
-    in all cases other than property names and the value(s) of the
-    <code>type</code> property.
+    Over reliance on the Compact URI form can lead to ambiguity and
+    interoperability issues between implementations. Therefore, Compact URI use
+    SHOULD be avoided in all cases other than property names and the value(s)
+    of the <code>type</code> property.
   </p>
 
 </section>
@@ -2731,10 +2768,11 @@ _:c14n0 a gsp:Geometry ;
       <h2>Re-serialization of Extensions</h2>
 
       <p>
-        Implementations that parse and then reserialize Activity Streams
-        2.0 documents that contain extension properties SHOULD take
-        sufficient care to ensure that extension properties used within
-        the original document are preserved and serialized appropriately.
+        Implementations that use JSON-LD mechanisms to parse and then
+        reserialize Activity Streams 2.0 documents that contain extension
+        properties SHOULD take sufficient care to ensure that extension
+        properties used within the original document are preserved and
+        serialized appropriately.
       </p>
 
       <p>
@@ -2801,6 +2839,54 @@ _:c14n0 a gsp:Geometry ;
 
     </section>
 
+  </section>
+
+  <section id="privacy">
+    <h2>Privacy Considerations</h2>
+    
+    <p>
+      Activity Streams 2.0 documents can (and likely will) contain potentially
+      sensitive personal information such as identity, contact information,
+      physical location, physical characteristics, and so forth. Furthermore,
+      Activity data, in general, can be analyzed to generate profiles of the
+      behavior of individual or groups of Actors.
+    </p>
+    
+    <p>
+      Implementations that produce or consume Activity Streams 2.0 documents
+      MUST take steps to openly and publicly document and communicate to all
+      potential users: (a) the kinds of potentially sensitive personal
+      information published, consumed or collected by the implementation, (b)
+      the reasons for publishing, consuming and collecting that information,
+      (c) the manner in which that information is being used, (d) the
+      identity of any other party with whom that information is being shared,
+      and (e) the reason the information is being shared with other parties.
+    </p>
+    
+    <p>
+      Implementations that publish Activity Streams 2.0 documents SHOULD
+      assume a default position of limiting both the kind and amount of
+      sensitive personal information included in the document unless users have
+      "opted in" to sharing additional detail.
+    </p>
+    
+    <p>
+      Implementations that consume Activity Streams 2.0 documents SHOULD NOT,
+      by default, store or share sensitive personal information included within
+      consumed documents unless users have "opted in" to allowing that
+      information to be stored or shared.
+    </p>
+    
+    <p>
+      In this context, "opting in" does not necessarily require explicit
+      action on the part of the user. If, for instance, the use of certain
+      sensitive personal information is clearly implicit in the use of an
+      implementation (a location tracking service, for example), then any
+      use of that implementation can be considered an implicit acknowledgement
+      that the sensitive personal information will be used and shared so long
+      as the documentation guidelines listed above are followed.
+    </p>
+    
   </section>
 
   <section id="security-considerations">

--- a/activitystreams-core/index.html
+++ b/activitystreams-core/index.html
@@ -870,7 +870,8 @@ _:b0 a as:Collection ;
           <code><a href="../activitystreams-vocabulary/#dfn-bto">bto</a></code> |
           <code><a href="../activitystreams-vocabulary/#dfn-cc">cc</a></code> |
           <code><a href="../activitystreams-vocabulary/#dfn-bcc">bcc</a></code> |
-          <code><a href="../activitystreams-vocabulary/#dfn-mediatype">mediaType</a></code>
+          <code><a href="../activitystreams-vocabulary/#dfn-mediatype">mediaType</a></code> |
+          <code><a href="../activitystreams-vocabulary/#dfn-duration">duration</a></code>
         </code>
       </p>
 
@@ -1098,8 +1099,7 @@ _:b0 a as:Place, gr:Location ;
           <code><a href="../activitystreams-vocabulary/#dfn-mediatype">mediaType</a></code> |
           <code><a href="../activitystreams-vocabulary/#dfn-rel">rel</a></code> |
           <code><a href="../activitystreams-vocabulary/#dfn-height">height</a></code> |
-          <code><a href="../activitystreams-vocabulary/#dfn-width">width</a></code> |
-          <code><a href="../activitystreams-vocabulary/#dfn-duration">duration</a></code>
+          <code><a href="../activitystreams-vocabulary/#dfn-width">width</a></code>
       </p>
 
       <p>
@@ -1622,7 +1622,7 @@ _:c14n0 a as:Create ;
 <pre class="example highlight json"><code>{
   "@context": "http://www.w3.org/ns/activitystreams",
   "type": "Like",
-  "id": "http://www.test.example/activiy/1",
+  "id": "http://www.test.example/activity/1",
   "actor": "http://example.org/profiles/joe",
   "object": "http://example.com/notes/1",
   "published": "2014-09-30T12:34:56Z"
@@ -1668,7 +1668,7 @@ _:c14n0 a as:Create ;
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 @prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt; .
 
-&lt;http://www.test.example/activiy/1&gt; a as:Like ;
+&lt;http://www.test.example/activity/1&gt; a as:Like ;
   as:published "2014-09-30T12:34:56Z"^^xsd:dateTime ;
   as:actor &lt;http://example.org/profiles/joe&gt; ;
   as:object &lt;http://example.com/notes/1&gt; .</pre></div>
@@ -1714,7 +1714,7 @@ _:c14n0 a as:Create ;
 <pre class="example highlight json"><code>{
   "@context": "http://www.w3.org/ns/activitystreams",
   "type": ["Like", "http://schema.org/LikeAction"],
-  "id": "http://www.test.example/activiy/1",
+  "id": "http://www.test.example/activity/1",
   "actor": "http://example.org/profiles/joe",
   "object": "http://example.com/notes/1",
   "published": "2014-09-30T12:34:56Z"
@@ -1760,7 +1760,7 @@ _:c14n0 a as:Create ;
 >@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 @prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt; .
 
-&lt;http://www.test.example/activiy/1&gt; a as:Like, &lt;http://schema.org/LikeAction&gt;;
+&lt;http://www.test.example/activity/1&gt; a as:Like, &lt;http://schema.org/LikeAction&gt;;
   as:published "2014-09-30T12:34:56Z"^^xsd:dateTime ;
   as:actor &lt;http://example.org/profiles/joe&gt; ;
   as:object &lt;http://example.com/notes/1&gt; .</pre></div>

--- a/activitystreams-vocabulary/activitystreams2.owl
+++ b/activitystreams-vocabulary/activitystreams2.owl
@@ -71,7 +71,7 @@ as:author a owl:ObjectProperty,
             owl:DeprecatedProperty ;
   rdfs:label "author"@en ;
   rdfs:comment "Identifies the author of an object. Deprecated. Use as:attributedTo instead"@en;
-  rdfs:domain as:Content ;
+  rdfs:domain as:Object ;
   rdfs:subPropertyOf as:attributedTo ;
   rdfs:range [
     a owl:Class ;
@@ -433,11 +433,7 @@ as:duration a owl:DatatypeProperty ,
   rdfs:label "duration"@en ;
   rdfs:comment "The duration of the object"@en ;
   rdfs:range xsd:duration ;
-  rdfs:domain [
-    a owl:Class ;
-    owl:unionOf ( as:Content as:Link )
-  ] .
-
+  rdfs:domain as:Object .
 
 as:endTime a owl:DatatypeProperty ,
     owl:FunctionalProperty ;
@@ -451,10 +447,7 @@ as:height a owl:DatatypeProperty ,
   rdfs:label "height"@en ;
   rdfs:comment "The display height expressed as device independent pixels"@en ;
   rdfs:range xsd:nonNegativeInteger ;
-  rdfs:domain [
-    a owl:Class ;
-    owl:unionOf ( as:Content as:Link )
-  ] .
+  rdfs:domain as:Link .
 
 as:href a owl:DatatypeProperty ,
   owl:FunctionalProperty ;
@@ -627,10 +620,7 @@ as:width a owl:DatatypeProperty ,
   rdfs:label "width"@en ;
   rdfs:comment "Specifies the preferred display width of the content, expressed in terms of device independent pixels."@en ;
   rdfs:range xsd:nonNegativeInteger ;
-  rdfs:domain [
-    a owl:Class ;
-    owl:unionOf ( as:Content as:Link )
-  ] .
+  rdfs:domain as:Link .
 
 #################################################################
 #
@@ -689,7 +679,7 @@ as:Arrive a owl:Class ;
 
 as:Article a owl:Class ;
   rdfs:label "Article"@en ;
-  rdfs:subClassOf as:Content ;
+  rdfs:subClassOf as:Object ;
   rdfs:comment "A written work. Typically several paragraphs long. For example, a blog post or a news article."@en .
 
 as:Audio a owl:Class ;
@@ -717,11 +707,6 @@ as:Relationship a owl:Class, rdf:Statement ;
   rdfs:subClassOf as:Object ;
   rdfs:comment "Represents a Social Graph relationship between two Individuals (indicated by the 'a' and 'b' properties)"@en .
 
-as:Content a owl:Class ;
-  rdfs:label "Content"@en ;
-  rdfs:subClassOf as:Object ;
-  rdfs:comment "An Object that has content"@en .
-
 as:Create a owl:Class ;
   rdfs:label "Create"@en ;
   rdfs:subClassOf as:Activity ;
@@ -739,7 +724,7 @@ as:Dislike a owl:Class ;
 
 as:Document a owl:Class ;
   rdfs:label "Document"@en ;
-  rdfs:subClassOf as:Content ;
+  rdfs:subClassOf as:Object ;
   rdfs:comment "Represents a digital document/file of any sort"@en .
 
 as:Event a owl:Class ;
@@ -829,7 +814,7 @@ as:Mention a owl:Class ;
 
 as:Note a owl:Class ;
   rdfs:label "Note"@en ;
-  rdfs:subClassOf as:Content ;
+  rdfs:subClassOf as:Object ;
   rdfs:comment "A Short note, typically less than a single paragraph. A \"tweet\" is an example, or a \"status update\""@en .
 
 as:Object a owl:Class ;
@@ -892,7 +877,7 @@ as:OrderedItems a owl:Class ;
 
 as:Page a owl:Class ;
   rdfs:label "Page"@en ;
-  rdfs:subClassOf as:Content ;
+  rdfs:subClassOf as:Object ;
   rdfs:comment "A Web Page"@en .
 
 as:Person a owl:Class ;
@@ -907,7 +892,7 @@ as:Organization a owl:Class ;
 
 as:Profile a owl:Class ;
   rdfs:label "Profile"@en;
-  rdfs:subClassOf as:Content ;
+  rdfs:subClassOf as:Object ;
   rdfs:comment "A Profile Document"@en .
 
 as:Place a owl:Class ;
@@ -917,7 +902,7 @@ as:Place a owl:Class ;
 
 as:Question a owl:Class ;
   rdfs:label "Question"@en;
-  rdfs:subClassOf as:Content, as:IntransitiveActivity ;
+  rdfs:subClassOf as:IntransitiveActivity ;
   rdfs:comment "A question of any sort."@en .
 
 as:Reject a owl:Class ;

--- a/activitystreams-vocabulary/index.html
+++ b/activitystreams-vocabulary/index.html
@@ -306,7 +306,7 @@
           <td>
             Describes an object of any kind. The Object class serves as the
             base class for most of the other kinds of objects defined in the
-            Activity Vocabulary, include other Core classes such as
+            Activity Vocabulary, including other Core classes such as
             <code><a>Activity</a></code>,
             <code><a>IntransitiveActivity</a></code>,
             <code><a>Actor</a></code>,
@@ -4676,6 +4676,142 @@ _:b0 a as:Dislike ;
             <td>Inherits all properties from <code><a>Activity</a></code>.</td>
           </tr>
         </tbody>
+        <tbody>
+          <tr>
+            <td rowspan="4" ><dfn>Question</dfn></td>
+            <td  style="width: 10%">URI:</td>
+            <td><code>http://www.w3.org/ns/activitystreams#Question</code></td>
+            <td rowspan="4" >
+<div class="nanotabs">
+  <ul>
+    <li><a href="#ex55-jsonld" class="selected">JSON</a></li>
+    <li><a href="#ex55-microdata" class="selected">Microdata</a></li>
+    <li><a href="#ex55-rdfa" class="selected">RDFa</a></li>
+    <li><a href="#ex55-microformats" class="selected">Microformats</a></li>
+    <li><a href="#ex55-turtle" class="selected">Turtle</a></li>
+  </ul>
+  <div id="ex55-jsonld" style="display: block;">
+<pre class="example highlight json">{
+  "@context": "http://www.w3.org/ns/activitystreams",
+  "type": "Question",
+  "name": "What is the answer?",
+  "oneOf": [
+    {
+      "type": "Note",
+      "name": "Option A"
+    },
+    {
+      "type": "Note",
+      "name": "Option B"
+    }
+  ]
+}</pre>
+</div>
+<div id="ex55-microdata" style="display:none;">
+<pre class="example highlight html"
+>&lt;div itemscope
+  itemtype="http://www.w3.org/ns/activitystreams#Question">
+  &lt;h2 itemprop="name">
+    What is the answer?
+  &lt;/h2>
+  &lt;ul&gt;
+    &lt;li itemprop="oneOf" itemscope
+      itemtype="http://www.w3.org/ns/activitystreams#Note"&gt;
+      &lt;span itemprop="name">Option A&lt;/span&gt;
+    &lt;/li&gt;
+    &lt;li itemprop="oneOf" itemscope
+      itemtype="http://www.w3.org/ns/activitystreams#Note"&gt;
+      &lt;span itemprop="name">Option B&lt;/span&gt;
+    &lt;/li&gt;
+  &lt;ul&gt;
+&lt;/div></pre>
+  </div>
+  <div id="ex55-rdfa" style="display:none;">
+<pre class="example highlight html"
+>&lt;div vocab="http://www.w3.org/ns/activitystreams#"
+  typeof="Question">
+  &lt;h2 property="name">What is the answer?&lt;/h2>
+  &lt;ol>
+    &lt;li property="oneOf" typeof="Note">
+      &lt;span property="name">
+        Option A
+      &lt;/span>
+    &lt;/li>
+    &lt;li property="oneOf" typeof="Note">
+      &lt;span property="name">
+        Option B
+      &lt;/span>
+    &lt;/li>
+  &lt;/ol>
+&lt;/div></pre>
+  </div>
+  <div id="ex55-microformats" style="display:none;">
+<pre class="example highlight html"
+>&lt;div class="h-as-question">
+  &lt;h2 class="p-name">
+    What is the answer?
+  &lt;/h2>
+  &lt;ul class="p-as-one-of"&gt;
+    &lt;li class="h-entry"&gt;
+      &lt;span class-"p-name">Option A&lt;/span&gt;
+    &lt;/li&gt;
+    &lt;li class="h-entry"&gt;
+      &lt;span class-"p-name">Option B&lt;/span&gt;
+    &lt;/li&gt;
+  &lt;ul&gt;
+&lt;/div></pre>
+  </div>
+<div id="ex55-turtle" style="display: none;">
+<pre class="example highlight turtle">
+@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
+
+_:b0 a as:Question ;
+  as:name "What is the answer?" ;
+  as:oneOf
+    [
+      a as:Note ;
+        as:name "Option A"
+    ] ,
+    [
+      a as:Note ;
+        as:name "Option B"
+    ] .</pre>
+  </div>
+</div>
+            </td>
+          </tr>
+          <tr>
+            <td>Notes:</td>
+            <td>
+              <p>
+                Represents a question being asked. Question objects are an
+                extension of <code><a>IntransitiveActivity</a></code>. That is,
+                the Question object is an Activity, but the direct object is
+                the question itself and therefore it would not contain an
+                <code><a>object</a></code> property.
+              </p>
+              <p>
+                Either of the <code><a>anyOf</a></code> and
+                <code><a>oneOf</a></code> properties MAY be used to express
+                possible answers, but a Question object MUST NOT have
+                both properties.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td>Extends:</td>
+            <td><code><a>IntransitiveActivity</a></code>.</td>
+          </tr>
+          <tr>
+            <td>Properties:</td>
+            <td>
+              <p><code><a>oneOf</a></code> | <code><a>anyOf</a></code></p>
+
+              Inherits all properties from
+              <code><a>IntransitiveActivity</a></code>.
+            </td>
+          </tr>
+        </tbody>
 
       </table>
 
@@ -5040,10 +5176,11 @@ _:b0 a as:Service ;
 
     <section id="object-types">
 
-      <h2>Object Types</h2>
+      <h2>Object and Link Types</h2>
 
       <p>
         All Object Types inherit the properties of the base <a>Object</a> class.
+        Link Types inherit the properties of the base <a>Link</a> class.
         Some specific Object Types are subclasses or specializations of more
         generalized Object Types (for instance, the <code><a>Person</a></code>
         Object Type is a more specific form of the <code><a>Actor</a></code> class).
@@ -5057,14 +5194,19 @@ _:b0 a as:Service ;
           <li><code><a>Document</a></code></li>
           <li><code><a>Event</a></code></li>
           <li><code><a>Image</a></code></li>
-          <li><code><a>Mention</a></code></li>
           <li><code><a>Note</a></code></li>
           <li><code><a>Page</a></code></li>
           <li><code><a>Place</a></code></li>
           <li><code><a>Profile</a></code></li>
-          <li><code><a>Question</a></code></li>
           <li><code><a>Relationship</a></code></li>
           <li><code><a>Video</a></code></li>
+        </ul>
+      </p>
+      
+      <p>
+        The Link Types include:
+        <ul>
+          <li><code><a>Mention</a></code></li>
         </ul>
       </p>
 
@@ -5788,142 +5930,6 @@ _:b0 a as:Page ;
           <tr>
             <td>Properties:</td>
             <td>Inherits all properties from <code><a>Document</a></code>.</td>
-          </tr>
-        </tbody>
-        <tbody>
-          <tr>
-            <td rowspan="4" ><dfn>Question</dfn></td>
-            <td  style="width: 10%">URI:</td>
-            <td><code>http://www.w3.org/ns/activitystreams#Question</code></td>
-            <td rowspan="4" >
-<div class="nanotabs">
-  <ul>
-    <li><a href="#ex55-jsonld" class="selected">JSON</a></li>
-    <li><a href="#ex55-microdata" class="selected">Microdata</a></li>
-    <li><a href="#ex55-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex55-microformats" class="selected">Microformats</a></li>
-    <li><a href="#ex55-turtle" class="selected">Turtle</a></li>
-  </ul>
-  <div id="ex55-jsonld" style="display: block;">
-<pre class="example highlight json">{
-  "@context": "http://www.w3.org/ns/activitystreams",
-  "type": "Question",
-  "name": "What is the answer?",
-  "oneOf": [
-    {
-      "type": "Note",
-      "name": "Option A"
-    },
-    {
-      "type": "Note",
-      "name": "Option B"
-    }
-  ]
-}</pre>
-</div>
-<div id="ex55-microdata" style="display:none;">
-<pre class="example highlight html"
->&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Question">
-  &lt;h2 itemprop="name">
-    What is the answer?
-  &lt;/h2>
-  &lt;ul&gt;
-    &lt;li itemprop="oneOf" itemscope
-      itemtype="http://www.w3.org/ns/activitystreams#Note"&gt;
-      &lt;span itemprop="name">Option A&lt;/span&gt;
-    &lt;/li&gt;
-    &lt;li itemprop="oneOf" itemscope
-      itemtype="http://www.w3.org/ns/activitystreams#Note"&gt;
-      &lt;span itemprop="name">Option B&lt;/span&gt;
-    &lt;/li&gt;
-  &lt;ul&gt;
-&lt;/div></pre>
-  </div>
-  <div id="ex55-rdfa" style="display:none;">
-<pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Question">
-  &lt;h2 property="name">What is the answer?&lt;/h2>
-  &lt;ol>
-    &lt;li property="oneOf" typeof="Note">
-      &lt;span property="name">
-        Option A
-      &lt;/span>
-    &lt;/li>
-    &lt;li property="oneOf" typeof="Note">
-      &lt;span property="name">
-        Option B
-      &lt;/span>
-    &lt;/li>
-  &lt;/ol>
-&lt;/div></pre>
-  </div>
-  <div id="ex55-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-as-question">
-  &lt;h2 class="p-name">
-    What is the answer?
-  &lt;/h2>
-  &lt;ul class="p-as-one-of"&gt;
-    &lt;li class="h-entry"&gt;
-      &lt;span class-"p-name">Option A&lt;/span&gt;
-    &lt;/li&gt;
-    &lt;li class="h-entry"&gt;
-      &lt;span class-"p-name">Option B&lt;/span&gt;
-    &lt;/li&gt;
-  &lt;ul&gt;
-&lt;/div></pre>
-  </div>
-<div id="ex55-turtle" style="display: none;">
-<pre class="example highlight turtle">
-@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
-
-_:b0 a as:Question ;
-  as:name "What is the answer?" ;
-  as:oneOf
-    [
-      a as:Note ;
-        as:name "Option A"
-    ] ,
-    [
-      a as:Note ;
-        as:name "Option B"
-    ] .</pre>
-  </div>
-</div>
-            </td>
-          </tr>
-          <tr>
-            <td>Notes:</td>
-            <td>
-              <p>
-                Represents a question being asked. Question objects are an
-                extension of <code><a>IntransitiveActivity</a></code>. That is,
-                the Question object is an Activity, but the direct object is
-                the question itself and therefore it would not contain an
-                <code><a>object</a></code> property.
-              </p>
-              <p>
-                Either of the <code><a>anyOf</a></code> and
-                <code><a>oneOf</a></code> properties MAY be used to express
-                possible answers, but a Question object MUST NOT have
-                both properties.
-              </p>
-            </td>
-          </tr>
-          <tr>
-            <td>Extends:</td>
-            <td><code><a>IntransitiveActivity</a></code>.</td>
-          </tr>
-          <tr>
-            <td>Properties:</td>
-            <td>
-              <p><code><a>oneOf</a></code> | <code><a>anyOf</a></code></p>
-
-              Inherits all properties from
-              <code><a>IntransitiveActivity</a></code>.
-            </td>
           </tr>
         </tbody>
         <tbody>
@@ -15449,6 +15455,231 @@ _:b0 a as:Profile ;
     activity's <code>object</code>.
   </p>
 
+</section>
+
+<section id="motivations" class="informative">
+  <h3>Activity Type Motivating Use Cases</h3>
+  
+  <p>
+    The <a href="#activity-types">Activity types</a> defined in this
+    vocabulary have been primarily selected to address the commonly implemented social use cases described below.
+  </p>
+  
+  <section id="motivations-crud">
+    <h4>Content Management</h4>
+    
+    <p>
+      The Content Management use case primarily deals with activities
+      that involve the creation, modification or deletion of content.
+      This includes, for instance, activities such as "John created a new
+      note", "Sally updated an article", and "Joe deleted the photo".
+    </p>
+    
+    <p>Relevant Activities:
+      <ul>
+        <li><code><a>Create</a></code></li>
+        <li><code><a>Delete</a></code></li>
+        <li><code><a>Update</a></code></li>
+      </ul>
+    </p>
+  </section>
+  
+  <section id="motivations-collections">
+    <h4>Collection Management</h4>
+    
+    <p>
+      The Collection Management use case primarily deals with activities
+      involving the management of content within collections. Examples of
+      collections include things like folders, albums, friend lists, etc.
+      This includes, for instance, activities such as "Sally added a file
+      to Folder A", "John moved the file from Folder A to Folder B", etc.
+    </p>
+    
+    <p>Relevant Activities:
+      <ul>
+        <li><code><a>Add</a></code></li>
+        <li><code><a>Move</a></code></li>
+        <li><code><a>Remove</a></code></li>
+      </ul>
+    </p>
+  </section>
+  
+  <section id="motivations-respond">
+    <h4>Reactions</h4>
+    
+    <p>
+      The Reactions use case primarily deals with reactions to content.
+      This can include activities such as liking or disliking content,
+      ignoring updates, flagging content as being inappropriate, accepting
+      or rejecting objects, etc.
+    </p>
+    
+    <p>Relevant Activities:
+      <ul>
+        <li><code><a>Accept</a></code></li>
+        <li><code><a>Block</a></code></li>
+        <li><code><a>Dislike</a></code></li>
+        <li><code><a>Flag</a></code></li>
+        <li><code><a>Ignore</a></code></li>
+        <li><code><a>Like</a></code></li>
+        <li><code><a>Reject</a></code></li>
+        <li><code><a>TentativeAccept</a></code></li>
+        <li><code><a>TentativeReject</a></code></li>
+      </ul>
+    </p>
+  </section>
+  
+  <section id="motivations-rsvp">
+    <h4>Event RSVP</h4>
+    
+    <p>
+      The Event RSVP use case primarily deals with invitations to events
+      and RSVP type responses.
+    </p>
+    
+    <p>Relevant Activities:
+      <ul>
+        <li><code><a>Accept</a></code></li>
+        <li><code><a>Ignore</a></code></li>
+        <li><code><a>Invite</a></code></li>
+        <li><code><a>Reject</a></code></li>
+        <li><code><a>TentativeAccept</a></code></li>
+        <li><code><a>TentativeReject</a></code></li>
+      </ul>
+    </p>
+  </section>
+  
+  <section id="motivations-group">
+    <h4>Group Management</h4>
+    
+    <p>
+      The Group Management use case primarily deals with management of
+      groups. It can include, for instance, activities such as "John added
+      Sally to Group A", "Sally joined Group A", "Joe left Group A", etc.
+    </p>
+    
+    <p>Relevant Activities:
+      <ul>
+        <li><code><a>Add</a></code></li>
+        <li><code><a>Join</a></code></li>
+        <li><code><a>Leave</a></code></li>
+        <li><code><a>Remove</a></code></li>
+      </ul>
+    </p>
+  </section>
+  
+  <section id="motivations-experience">
+    <h4>Content Experience</h4>
+    
+    <p>
+      The Content Experience use case primarily deals with describing
+      activities involving listening to, reading, or viewing content.
+      For instance, "Sally read the article", "Joe listened to the song".
+    </p>
+    
+    <p>Relevant Activities:
+      <ul>
+        <li><code><a>Listen</a></code></li>
+        <li><code><a>Read</a></code></li>
+        <li><code><a>View</a></code></li>
+      </ul>
+    </p>
+  </section>
+  
+  <section id="motivations-geo">
+    <h4>Geo-Social Events</h4>
+    <p>
+      The Geo-Social Events use case primarily deals with activities
+      involving geo-tagging type activities. For instance, it can include
+      activities such as "Joe arrived at work", "Sally left work", and
+      "John is travel from home to work".
+    </p>
+    <p>Relevant Activities:
+      <ul>
+        <li><code><a>Arrive</a></code></li>
+        <li><code><a>Leave</a></code></li>
+        <li><code><a>Travel</a></code></li>
+      </ul>
+    </p>
+  </section>
+  
+  <section id="motivations-notification">
+    <h4>Notification</h4>
+    <p>
+      The Notification use case primarily deals with calling attention to
+      particular objects or notifications.
+    </p>
+    <p>Relevant Activities:
+      <ul>
+        <li><code><a>Announce</a></code></li>
+      </ul>
+    </p>
+  </section>
+  
+  <section id="motivations-questions">
+    <h4>Questions</h4>
+    <p>
+      the Questions use case primarily deals with representing inquiries
+      of any type. See <a href="questions"></a> for more information.
+    </p>
+    <p>Relevant Activities:
+      <ul>
+        <li><code><a>Question</a></code></li>
+      </ul>
+    </p>
+  </section>
+  
+  <section id="motivations-relationships">
+    <h4>Relationship Management</h4>
+    <p>
+      The Relationship Management use case primarily deals with representing
+      activities involving the management of interpersonal and social
+      relationships (e.g. friend requests, management of social network, etc).
+      See <a href="#connections"></a> for more information.
+    </p>
+    <p>Relevant Activities:
+      <ul>
+        <li><code><a>Accept</a></code></li>
+        <li><code><a>Add</a></code></li>
+        <li><code><a>Block</a></code></li>
+        <li><code><a>Create</a></code></li>
+        <li><code><a>Delete</a></code></li>
+        <li><code><a>Follow</a></code></li>
+        <li><code><a>Ignore</a></code></li>
+        <li><code><a>Invite</a></code></li>
+        <li><code><a>Reject</a></code></li>
+      </ul>
+    </p>
+  </section>
+  
+  <section id="motivations-undo">
+    <h4>Negating Activity</h4>
+    <p>
+      The Negating Activity use case primarily deals with the ability to
+      redact previously completed activities.
+    </p>
+    <p>Relevant Activities:
+      <ul>
+        <li><code><a>Undo</a></code></li>
+      </ul>
+    </p>
+  </section>
+  
+  <section id="motivations-offer">
+    <h4>Offers</h4>
+    <p>
+      The Offers use case deals with activities involving offering one
+      object to another. It can include, for instance, activities such as
+      "Company A is offering a discount on purchase of Product Z to Sally",
+      "Sally is offering to add a File to Folder A", etc.
+    </p>
+    <p>Relevant Activities:
+      <ul>
+        <li><code><a>Offer</a></code></li>
+      </ul>
+    </p>
+  </section>
+  
 </section>
 
 </section>

--- a/activitystreams-vocabulary/index.html
+++ b/activitystreams-vocabulary/index.html
@@ -346,7 +346,8 @@
               <code><a>bto</a></code> |
               <code><a>cc</a></code> |
               <code><a>bcc</a></code> |
-              <code><a>mediaType</a></code>
+              <code><a>mediaType</a></code> |
+              <code><a>duration</a></code>
             </p>
           </td>
         </tr>
@@ -448,8 +449,7 @@ _:b0 a as:Link ;
               <code><a>name</a></code> |
               <code><a>hreflang</a></code> |
               <code><a>height</a></code> |
-              <code><a>width</a></code> |
-              <code><a>duration</a></code>
+              <code><a>width</a></code>
             </p>
           </td>
         </tr>
@@ -5054,7 +5054,6 @@ _:b0 a as:Service ;
         <ul>
           <li><code><a>Article</a></code></li>
           <li><code><a>Audio</a></code></li>
-          <li><code><a>Content</a></code></li>
           <li><code><a>Document</a></code></li>
           <li><code><a>Event</a></code></li>
           <li><code><a>Image</a></code></li>
@@ -5196,106 +5195,6 @@ _:b0 a as:Relationship ;
           </tr>
         </tbody>
 
-      <tbody>
-        <tr>
-          <td rowspan="4" ><dfn>Content</dfn></td>
-          <td  style="width: 10%">URI:</td>
-          <td><code>http://www.w3.org/ns/activitystreams#Content</code></td>
-          <td rowspan="4" >
-<div class="nanotabs">
-  <ul>
-    <li><a href="#ex35-jsonld" class="selected">JSON</a></li>
-    <li><a href="#ex35-microdata" class="selected">Microdata</a></li>
-    <li><a href="#ex35-rdfa" class="selected">RDFa</a></li>
-    <li><a href="#ex35-microformats" class="selected">Microformats</a></li>
-    <li><a href="#ex35-turtle" class="selected">Turtle</a></li>
-  </ul>
-  <div id="ex35-jsonld" style="display: block;">
-<pre class="example highlight json">{
-  "@context": "http://www.w3.org/ns/activitystreams",
-  "type": "Content",
-  "name": "Some generic content",
-  "content": "&lt;p>This can be any kind of content&lt;/p>",
-  "height": 100,
-  "width": 100
-}</pre>
-</div>
-<div id="ex35-microdata" style="display:none;">
-<pre class="example highlight html"
->&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Content"
-  style="width:100px; height:100px">
-  &lt;div itemprop="name">Some generic content&lt;/div>
-  &lt;div itemprop="content">
-    &lt;p>This can be any kind of content&lt;/p>
-  &lt;/div>
-  &lt;meta itemprop="height" content="100" />
-  &lt;meta itemprop="width" content="100" />
-&lt;/div></pre>
-  </div>
-  <div id="ex35-rdfa" style="display:none;">
-<pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Content" style="width:100px; height:100px">
-  &lt;div property="name">Some generic content&lt;/div>
-  &lt;div property="content" datatype="rdf:HTML">
-    &lt;p>This can be any kind of content&lt;/p>
-  &lt;/div>
-  &lt;meta property="height" content="100" datatype="xsd:nonNegativeInteger" />
-  &lt;meta property="width" content="100" datatype="xsd:nonNegativeInteger" />
-&lt;/div></pre>
-  </div>
-  <div id="ex35-microformats" style="display:none;">
-<pre class="example highlight html"
->&lt;div class="h-entry" style="width:100px; height:100px">
-  &lt;div property="p-name">Some generic content&lt;/div>
-  &lt;div property="e-content">
-    &lt;p>This can be any kind of content&lt;/p>
-  &lt;/div>
-&lt;/div></pre>
-  </div>
-<div id="ex35-turtle" style="display: none;">
-<pre class="example highlight turtle">
-@prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
-@prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt; .
-
-_:b0 a as:Content ;
-  as:name "Some generic content" ;
-  as:content "&lt;p>This can be any kind of content&gt;/p>" ;
-  as:height "100"^^xsd:nonNegativeInteger ;
-  as:width "100"^^xsd:nonNegativeInteger .</pre>
-  </div>
-</div>
-          </td>
-        </tr>
-        <tr>
-          <td>Notes:</td>
-          <td>
-            Describes an entity representing any form of content. Examples
-            include documents, images, etc. Content objects
-            typically are not able to perform activities on their own, yet
-            rather are usually the object or target of activities.
-          </td>
-        </tr>
-        <tr>
-          <td>Extends:</td>
-          <td><code><a>Object</a></code></td>
-        </tr>
-        <tr>
-          <td>Properties:</td>
-          <td>
-            <p>
-              <code><a>duration</a></code> |
-              <code><a>height</a></code> |
-              <code><a>width</a></code>
-            </p>
-
-            <p>
-              Inherits all properties from <code><a>Object</a></code>.
-            </p>
-          </td>
-        </tr>
-</tbody>
         <tbody>
           <tr>
             <td rowspan="4" ><dfn>Article</dfn></td>
@@ -5376,11 +5275,11 @@ _:b0 a as:Article ;
           </tr>
           <tr>
             <td>Extends:</td>
-            <td><code><a>Content</a></code></td>
+            <td><code><a>Object</a></code></td>
           </tr>
           <tr>
             <td>Properties:</td>
-            <td>Inherits all properties from <code><a>Content</a></code>.</td>
+            <td>Inherits all properties from <code><a>Object</a></code>.</td>
           </tr>
         </tbody>
         <tbody>
@@ -5451,11 +5350,11 @@ _:b0 a as:Document ;
           </tr>
           <tr>
             <td>Extends:</td>
-            <td><code><a>Content</a></code></td>
+            <td><code><a>Object</a></code></td>
           </tr>
           <tr>
             <td>Properties:</td>
-            <td>Inherits all properties from <code><a>Content</a></code>.</td>
+            <td>Inherits all properties from <code><a>Object</a></code>.</td>
           </tr>
         </tbody>
         <tbody>
@@ -5811,11 +5710,11 @@ _:b0 a as:Note ;
           </tr>
           <tr>
             <td>Extends:</td>
-            <td><code><a>Content</a></code></td>
+            <td><code><a>Object</a></code></td>
           </tr>
           <tr>
             <td>Properties:</td>
-            <td>Inherits all properties from <code><a>Content</a></code>.</td>
+            <td>Inherits all properties from <code><a>Object</a></code>.</td>
           </tr>
         </tbody>
         <tbody>
@@ -5999,12 +5898,11 @@ _:b0 a as:Question ;
             <td>Notes:</td>
             <td>
               <p>
-                Represents a question being asked. Question objects are unique
-                in that they are an extension of both
-                <code><a>Content</a></code> and
-                <code><a>IntransitiveActivity</a></code>. That is, the
-                Question object is an Activity but the direct object is the
-                question itself.
+                Represents a question being asked. Question objects are an
+                extension of <code><a>IntransitiveActivity</a></code>. That is,
+                the Question object is an Activity, but the direct object is
+                the question itself and therefore it would not contain an
+                <code><a>object</a></code> property.
               </p>
               <p>
                 Either of the <code><a>anyOf</a></code> and
@@ -6016,14 +5914,14 @@ _:b0 a as:Question ;
           </tr>
           <tr>
             <td>Extends:</td>
-            <td><code><a>Content</a></code> AND <code><a>IntransitiveActivity</a></code>.</td>
+            <td><code><a>IntransitiveActivity</a></code>.</td>
           </tr>
           <tr>
             <td>Properties:</td>
             <td>
               <p><code><a>oneOf</a></code> | <code><a>anyOf</a></code></p>
 
-              Inherits all properties from <code><a>Content</a></code> and
+              Inherits all properties from
               <code><a>IntransitiveActivity</a></code>.
             </td>
           </tr>
@@ -6471,13 +6369,13 @@ _:b0 a as:Profile ;
           </tr>
           <tr>
             <td>Extends:</td>
-            <td><code><a>Content</a></code></td>
+            <td><code><a>Object</a></code></td>
           </tr>
           <tr>
             <td>Properties:</td>
             <td>
               <p><code><a>describes</a></code></p>
-              <p>Inherits all properties from <code><a>Content</a></code>.</p>
+              <p>Inherits all properties from <code><a>Object</a></code>.</p>
             </td>
           </tr>
         </tbody>
@@ -10660,11 +10558,13 @@ _:b0 a as:CollectionPage ;
   "name": "Cool New Movie",
   "duration": "PT2H30M",
   "preview": {
-    "type": "Link",
+    "type": "Video",
     "name": "Trailer",
-    "href": "http://example.org/trailer.mkv",
-    "mediaType": "video/mkv",
-    "duration": "PT1M"
+    "duration": "PT1M",
+    "url": {
+      "href": "http://example.org/trailer.mkv",
+      "mediaType": "video/mkv"
+    }
   }
 }</pre>
 </div>
@@ -10672,15 +10572,13 @@ _:b0 a as:CollectionPage ;
 <pre class="example highlight html"
 >&lt;div itemscope
   itemtype="http://www.w3.org/ns/activitystreams#Video">
-  &lt;span itemprop="name">
-    Cool New Movie
-  &lt;/span>
+  &lt;span itemprop="name">Cool New Movie&lt;/span>
   &lt;meta itemprop="duration" content="PT2H30M">(2H 30M)&lt;/meta>
   - &lt;span itemprop="preview" itemscope
-    itemtype="http://www.w3.org/ns/activitystreams#Link">
+      itemtype="http://www.w3.org/ns/activitystreams#Video">
     &lt;span itemprop="name">Trailer&lt;span>
     &lt;meta itemprop="duration" content="PT1M">(1M)&lt;/meta>
-    &lt;a itemprop="href"
+    &lt;a itemprop="url"
       href="http://example.org/trailer.mkv"
       type="video/mkv">Watch&lt;/a>
   &lt;/span>
@@ -10688,17 +10586,16 @@ _:b0 a as:CollectionPage ;
   </div>
   <div id="ex106-rdfa" style="display:none;">
 <pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Video">
-  &lt;span property="name">
-    Cool New Movie
-  &lt;/span>
-  &lt;span property="duration" content="PT2H30M" datatype="xsd:duration">(2H 30M)&lt;/span> -
-  &lt;span property="preview" typeof="Link">
-    &lt;a property="name"
-      rel="href" href="http://example.org/trailer.mkv">Trailer&lt;/a>
-    &lt;span property="mediaType" lang="">video/mkv&lt;/span>
-    &lt;span property="duration" content="PT1M" datatype="xsd:duration">(1M)&lt;/span>
+>&lt;div vocab="http://www.w3.org/ns/activitystreams#" typeof="Video">
+  &lt;span property="name">Cool New Movie&lt;/span>
+  &lt;span property="duration" content="PT2H30M"
+    datatype="xsd:duration">(2H 30M)&lt;/span>
+  - &lt;span property="preview" typeof="Video">
+    &lt;span property="name">Trailer&lt;span>
+    &lt;meta property="duration" content="PT1M">(1M)&lt;/meta>
+    &lt;a property="url"
+      href="http://example.org/trailer.mkv"
+      type="video/mkv">Watch&lt;/a>
   &lt;/span>
 &lt;/div></pre>
   </div>
@@ -10727,11 +10624,13 @@ _:b0 a as:Video ;
   as:name "Cool New Movie" ;
   as:duration "PT2H30M"^^xsd:duration ;
   as:preview [
-    a as:Link ;
+    a as:Video ;
     as:name "Trailer" ;
-    as:href &lt;http://example.org/trailer.mkv> ;
-    as:mediaType "video/mkv" ;
-    as:duration "PT1M"^^xsd:duration
+    as:duration "PT1M"^^xsd:duration ;
+    as:url [
+      as:href &lt;http://example.org/trailer.mkv> ;
+      as:mediaType "video/mkv"
+    ]
   ] .</pre>
   </div>
 </div>
@@ -12403,7 +12302,7 @@ _:b0 a as:Video ;
         </tr>
         <tr>
           <td>Domain:</td>
-          <td><code><a>Content</a></code> | <code><a>Link</a></code></td>
+          <td><code><a>Object</a></code></td>
         </tr>
         <tr>
           <td>Range:</td>
@@ -12432,55 +12331,37 @@ _:b0 a as:Video ;
   <div id="ex136-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "type": "Content",
-  "name": "Some generic content",
-  "content": "&lt;p>This can be any kind of content&lt;/p>",
+  "type": "Link",
+  "href": "http://example.org/image.png",
   "height": 100,
   "width": 100
 }</pre>
 </div>
 <div id="ex136-microdata" style="display:none;">
 <pre class="example highlight html"
->&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Content"
-  style="width:100px; height:100px">
-  &lt;div itemprop="name">Some generic content&lt;/div>
-  &lt;div itemprop="content">
-    &lt;p>This can be any kind of content&lt;/p>
-  &lt;/div>
-  &lt;meta itemprop="height" content="100" />
-  &lt;meta itemprop="width" content="100" />
-&lt;/div></pre>
+>&lt;img itemscope
+  itemtype="http://www.w3.org/ns/activitystreams#Link"
+  src="http://example.org/image.png"
+  height="100" width="100" /></pre>
   </div>
   <div id="ex136-rdfa" style="display:none;">
 <pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Content">
-  &lt;div property="name">Some generic content&lt;/div>
-  &lt;div property="content" datatype="rdf:HTML">
-    &lt;p>This can be any kind of content&lt;/p>
-  &lt;/div>
-  &lt;meta property="height" content="100" />
-  &lt;meta property="width" content="100" />
-&lt;/div></pre>
+>&lt;img vocab="http://www.w3.org/ns/activitystreams#"
+  typeof="Link" src="http://example.org/image.png"
+  height="100" width="100" /></pre>
   </div>
   <div id="ex136-microformats" style="display:none;">
 <pre class="example highlight html"
->&lt;div class="h-entry" style="width:100px; height:100px">
-  &lt;div property="p-name">Some generic content&lt;/div>
-  &lt;div property="e-content">
-    &lt;p>This can be any kind of content&lt;/p>
-  &lt;/div>
-&lt;/div></pre>
+>&lt;img src="http://example.org/image.png"
+  height="100" width="100" /></pre>
   </div>
 <div id="ex136-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 @prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt; .
 
-_:b0 a as:Content ;
-  as:name "Some generic content" ;
-  as:content "&lt;p>This can be any kind of content&lt;/p>" ;
+_:b0 a as:Link ;
+  as:href "http://example.org/image.png" ;
   as:height "100"^^xsd:nonNegativeInteger ;
   as:width "100"^^xsd:nonNegativeInteger .</pre>
   </div>
@@ -12490,15 +12371,14 @@ _:b0 a as:Content ;
         <tr>
           <td>Notes:</td>
           <td>
-            When the object describes a visual resource, such as an image,
-            video or embeddable HTML, the <code><a>height</a></code> property
-            indicates the recommended display height in properties of
-            device-independent pixels.
+            On a <code><a>Link</a></code>, specifies a hint as to the
+            rendering height in device-independent pixels of the linked
+            resource.
           </td>
         </tr>
         <tr>
           <td>Domain:</td>
-          <td><code><a>Content</a></code> | <code><a>Link</a></code></td>
+          <td><code><a>Link</a></code></td>
         </tr>
         <tr>
           <td>Range:</td>
@@ -14362,55 +14242,37 @@ _:b0 a as:Note ;
   <div id="ex159-jsonld" style="display: block;">
 <pre class="example highlight json">{
   "@context": "http://www.w3.org/ns/activitystreams",
-  "type": "Content",
-  "name": "Some generic content",
-  "content": "&lt;p>This can be any kind of content&lt;/p>",
+  "type": "Link",
+  "href": "http://example.org/image.png",
   "height": 100,
   "width": 100
 }</pre>
 </div>
 <div id="ex159-microdata" style="display:none;">
 <pre class="example highlight html"
->&lt;div itemscope
-  itemtype="http://www.w3.org/ns/activitystreams#Content"
-  style="width:100px; height:100px">
-  &lt;div itemprop="name">Some generic content&lt;/div>
-  &lt;div itemprop="content">
-    &lt;p>This can be any kind of content&lt;/p>
-  &lt;/div>
-  &lt;meta itemprop="height" content="100" />
-  &lt;meta itemprop="width" content="100" />
-&lt;/div></pre>
+>&lt;img itemscope
+  itemtype="http://www.w3.org/ns/activitystreams#Link"
+  src="http://example.org/image.png"
+  height="100" width="100" /></pre>
   </div>
   <div id="ex159-rdfa" style="display:none;">
 <pre class="example highlight html"
->&lt;div vocab="http://www.w3.org/ns/activitystreams#"
-  typeof="Content">
-  &lt;div property="name">Some generic content&lt;/div>
-  &lt;div property="content">
-    &lt;p>This can be any kind of content&lt;/p>
-  &lt;/div>
-  &lt;meta property="height" content="100" datatype="xsd:nonNegativeInteger" />
-  &lt;meta property="width" content="100" datatype="xsd:nonNegativeInteger" />
-&lt;/div></pre>
+>&lt;img vocab="http://www.w3.org/ns/activitystreams#"
+  typeof="Link" src="http://example.org/image.png"
+  height="100" width="100" /></pre>
   </div>
   <div id="ex159-microformats" style="display:none;">
 <pre class="example highlight html"
->&lt;div class="h-entry" style="width:100px; height:100px">
-  &lt;div class="p-name">Some generic content&lt;/div>
-  &lt;div class="e-content">
-    &lt;p>This can be any kind of content&lt;/p>
-  &lt;/div>
-&lt;/div></pre>
+>&lt;img src="http://example.org/image.png"
+  height="100" width="100" /></pre>
   </div>
 <div id="ex159-turtle" style="display: none;">
 <pre class="example highlight turtle">
 @prefix as: &lt;http://www.w3.org/ns/activitystreams#&gt; .
 @prefix xsd: &lt;http://www.w3.org/2001/XMLSchema#&gt; .
 
-_:b0 a as:Content ;
-  as:name "Some generic content" ;
-  as:content "&lt;p>This can be any kind of content&lt;/p>" ;
+_:b0 a as:Link ;
+  as:href "http://example.org/image.png" ;
   as:height "100"^^xsd:nonNegativeInteger ;
   as:width "100"^^xsd:nonNegativeInteger .</pre>
   </div>
@@ -14420,15 +14282,14 @@ _:b0 a as:Content ;
         <tr>
           <td>Notes:</td>
           <td>
-            When the object describes a visual resource, such as an image,
-            video or embeddable HTML, the <code><a>width</a></code> property
-            indicates the recommended display width in properties of
-            device-independent pixels.
+            On a <code><a>Link</a></code>, specifies a hint as to the
+            rendering width in device-independent pixels of the linked
+            resource.
           </td>
         </tr>
         <tr>
           <td>Domain:</td>
-          <td><code><a>Content</a> | <a>Link</a></code></td>
+          <td><code><a>Link</a></code></td>
         </tr>
         <tr>
           <td>Range:</td>

--- a/activitystreams-vocabulary/index.html
+++ b/activitystreams-vocabulary/index.html
@@ -15656,7 +15656,8 @@ _:b0 a as:Profile ;
     <h4>Negating Activity</h4>
     <p>
       The Negating Activity use case primarily deals with the ability to
-      redact previously completed activities.
+      redact previously completed activities. See <a href="#inverse"></a>
+      for more information.
     </p>
     <p>Relevant Activities:
       <ul>

--- a/activitystreams-vocabulary/index.html
+++ b/activitystreams-vocabulary/index.html
@@ -165,23 +165,12 @@
     <section id="termconventions">
 
       <h2>Conventions</h2>
-
-      <p>
-        This specification uses IRIs [[!RFC3987]].  Every URI [[!RFC3986]] is
-        also an IRI, so a URI may be used wherever an IRI is named.  There are
-        two special considerations: (1) when an IRI that is not also a URI is
-        given for dereferencing, it MUST be mapped to a URI using the steps
-        in Section 3.1 of [[!RFC3987]] and (2) when an IRI is serving as an "id"
-        value, it MUST NOT be so mapped.
-      </p>
-
+      
       <p>
         Unless otherwise specified, all properties defined as
-        <code>xsd:dateTime</code> values MUST conform to the "date-time"
-        production in [[!RFC3339]], with an uppercase "T" character used to
-        separate date and time, and an uppercase "Z" character in the absence
-        of a numeric time zone offset. All such timestamps SHOULD be
-        represented relative to Coordinated Universal Time (UTC).
+        <code>xsd:dateTime</code> values MUST conform to the rules
+        defined in Activity Streams 2.0 Core,
+        <a href="../activitystreams-core/#dates">Section 2.3</a>.
       </p>
 
       <p>


### PR DESCRIPTION
Remove Content:

* Simplifies and flattens the vocabulary
* height and width are limited to as:Link and are defined specifically
  as rendering hints
* Everything that previously derived from Content now derives
  directly from Object. (this has the side effect of eliminating
  the somewhat weird multiple inheritance on the Question object)
* duration property is removed from as:Link, it was just weird
  there. It's moved up to Object so that any Object can have a
  duration